### PR TITLE
Configure Vercel build for demo app

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,7 +1,7 @@
 import data from "./mapExport.json"
 import colors from "./colors.json"
-import {Renderer} from "../src";
-import MapReader from "../src/reader/MapReader";
+import {Renderer} from "@src";
+import MapReader from "@src/reader/MapReader";
 
 const el = document.getElementById("stage") as HTMLDivElement
 

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@src": ["../src/index.ts"],
+      "@src/*": ["../src/*"]
+    }
+  },
+  "include": ["./**/*.ts", "./**/*.tsx", "../src/types/**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -p tsconfig.json && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "demo:dev": "vite --config vite.demo.config.ts",
+    "demo:build": "vite build --config vite.demo.config.ts",
+    "demo:preview": "vite preview --config vite.demo.config.ts"
   },
   "dependencies": {
     "konva": "^10.0.2"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "yarn demo:build",
+  "outputDirectory": "demo/dist",
+  "devCommand": "yarn demo:dev"
+}

--- a/vite.demo.config.ts
+++ b/vite.demo.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import path from 'node:path';
+
+export default defineConfig({
+    root: 'demo',
+    resolve: {
+        alias: {
+            '@src': path.resolve(__dirname, 'src')
+        }
+    },
+    build: {
+        outDir: 'dist',
+        emptyOutDir: true
+    }
+});


### PR DESCRIPTION
## Summary
- add a dedicated Vite configuration for the demo with an alias to the source files
- add demo-specific scripts and TypeScript configuration to support the alias
- provide a Vercel configuration that builds the demo and serves the generated assets

## Testing
- yarn demo:build

------
https://chatgpt.com/codex/tasks/task_e_68deb6d334f0832a9bf05c7b56b49f78