### PR TITLE
Refactor direction helpers

### DIFF
--- a/src/ExitRenderer.ts
+++ b/src/ExitRenderer.ts
@@ -2,59 +2,12 @@ import Exit, {longToShort} from "./reader/Exit";
 import MapReader from "./reader/MapReader";
 import Konva from "konva";
 import {Settings} from "./Renderer";
-
-interface Point {
-    x: number;
-    y: number;
-}
+import {movePoint} from "./directions";
 
 const Colors = {
     OPEN_DOOR: 'rgb(10, 155, 10)',
     CLOSED_DOOR: 'rgb(226, 205, 59)',
-    LOCKED_DOOR: 'rgb(155, 10, 10'
-}
-
-function move(
-    x: number,
-    y: number,
-    direction?: MapData.direction,
-    distance: number = 1
-): Point {
-    if (!direction) {
-        return {x, y};
-    }
-    switch (direction) {
-        case "north":
-            y -= distance;
-            break;
-        case "south":
-            y += distance;
-            break;
-        case "east":
-            x += distance;
-            break;
-        case "west":
-            x -= distance;
-            break;
-        case "northeast":
-            x += distance;
-            y -= distance;
-            break;
-        case "northwest":
-            x -= distance;
-            y -= distance;
-            break;
-        case "southeast":
-            x += distance;
-            y += distance;
-            break;
-        case "southwest":
-            x -= distance;
-            y += distance;
-            break;
-    }
-
-    return {x, y};
+    LOCKED_DOOR: 'rgb(155, 10, 10)'
 }
 
 const dirNumbers: Record<number, MapData.direction> = {
@@ -112,8 +65,8 @@ export default class ExitRenderer {
         const exitRender = new Konva.Group();
 
         const points = []
-        points.push(...Object.values(move(sourceRoom.x, sourceRoom.y, exit.aDir, Settings.roomSize / 2)));
-        points.push(...Object.values(move(targetRoom.x, targetRoom.y, exit.bDir, Settings.roomSize / 2)));
+        points.push(...Object.values(movePoint(sourceRoom.x, sourceRoom.y, exit.aDir, Settings.roomSize / 2)));
+        points.push(...Object.values(movePoint(targetRoom.x, targetRoom.y, exit.bDir, Settings.roomSize / 2)));
 
         if (sourceRoom.doors[longToShort[exit.aDir]] || targetRoom.doors[longToShort[exit.bDir]]) {
             const door = this.renderDoor(points, sourceRoom.doors[longToShort[exit.aDir]] ?? targetRoom.doors[longToShort[exit.bDir]])
@@ -145,17 +98,17 @@ export default class ExitRenderer {
 
         let targetPoint = {x: targetRoom.x, y: targetRoom.y};
         if (targetRoom.area !== sourceRoom.area || targetRoom.z !== sourceRoom.z) {
-            targetPoint = move(sourceRoom.x, sourceRoom.y, dir, Settings.roomSize / 2);
+            targetPoint = movePoint(sourceRoom.x, sourceRoom.y, dir, Settings.roomSize / 2);
         }
 
-        const startPoint = move(sourceRoom.x, sourceRoom.y, dir, 0.3);
+        const startPoint = movePoint(sourceRoom.x, sourceRoom.y, dir, 0.3);
 
         const middlePointX = startPoint.x - (startPoint.x - targetPoint.x) / 2;
         const middlePointY = startPoint.y - (startPoint.y - targetPoint.y) / 2;
 
         const group = new Konva.Group();
         const points = []
-        points.push(...Object.values(move(sourceRoom.x, sourceRoom.y, dir, Settings.roomSize / 2)));
+        points.push(...Object.values(movePoint(sourceRoom.x, sourceRoom.y, dir, Settings.roomSize / 2)));
         points.push(targetPoint.x, targetPoint.y);
         const link = new Konva.Line({
             points,
@@ -183,8 +136,8 @@ export default class ExitRenderer {
     }
 
     renderAreaExit(room: MapData.Room, dir: MapData.direction) {
-        const start = move(room.x, room.y, dir, Settings.roomSize / 2)
-        const end = move(room.x, room.y, dir, Settings.roomSize * 1.5)
+        const start = movePoint(room.x, room.y, dir, Settings.roomSize / 2)
+        const end = movePoint(room.x, room.y, dir, Settings.roomSize * 1.5)
         return new Konva.Arrow({
             points: [start.x, start.y, end.x, end.y],
             pointerLength: 0.3,
@@ -232,8 +185,8 @@ export default class ExitRenderer {
     renderStubs(room: MapData.Room) {
         return room.stubs.map(stub => {
             const direction = dirNumbers[stub];
-            const start = move(room.x, room.y, direction, Settings.roomSize / 2)
-            const end = move(room.x, room.y, direction, Settings.roomSize / 2 + 0.5)
+            const start = movePoint(room.x, room.y, direction, Settings.roomSize / 2)
+            const end = movePoint(room.x, room.y, direction, Settings.roomSize / 2 + 0.5)
             const points = [start.x, start.y, end.x, end.y]
             return new Konva.Line({
                 points,
@@ -276,27 +229,27 @@ export default class ExitRenderer {
 
                 switch (exit) {
                     case "up":
-                        triangle.position(move(room.x, room.y, "south", Settings.roomSize / 4));
+                        triangle.position(movePoint(room.x, room.y, "south", Settings.roomSize / 4));
                         break;
                     case "down":
                         triangle.rotation(180);
-                        triangle.position(move(room.x, room.y, "north", Settings.roomSize / 4));
+                        triangle.position(movePoint(room.x, room.y, "north", Settings.roomSize / 4));
                         break;
                     case "in":
                         const inRender = triangle.clone()
                         inRender.rotation(-90);
-                        inRender.position(move(room.x, room.y, "east", Settings.roomSize / 4));
+                        inRender.position(movePoint(room.x, room.y, "east", Settings.roomSize / 4));
                         render.add(inRender);
                         triangle.rotation(90);
-                        triangle.position(move(room.x, room.y, "west", Settings.roomSize / 4));
+                        triangle.position(movePoint(room.x, room.y, "west", Settings.roomSize / 4));
                         break;
                     case "out":
                         const outRender = triangle.clone()
                         outRender.rotation(90);
-                        outRender.position(move(room.x, room.y, "east", Settings.roomSize / 4));
+                        outRender.position(movePoint(room.x, room.y, "east", Settings.roomSize / 4));
                         render.add(outRender);
                         triangle.rotation(-90);
-                        triangle.position(move(room.x, room.y, "west", Settings.roomSize / 4));
+                        triangle.position(movePoint(room.x, room.y, "west", Settings.roomSize / 4));
                         break;
                 }
                 return render

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -2,6 +2,12 @@ import Konva from "konva";
 import ExitRenderer from "./ExitRenderer";
 import MapReader from "./reader/MapReader";
 import Exit from "./reader/Exit";
+import {
+    movePoint,
+    PlanarDirection,
+    planarDirections,
+    oppositeDirections,
+} from "./directions";
 
 const defaultRoomSize = 0.6;
 const padding = 1;
@@ -139,18 +145,87 @@ export class Renderer {
     }
 
     renderPath(locations: number[]) {
-        const points = locations
+        if (this.currentArea === undefined || this.currentZIndex === undefined) {
+            return;
+        }
+
+        const rooms = locations
             .map(location => this.mapReader.getRoom(location))
-            .filter(room => room !== undefined && room.z === this.currentZIndex)
-            .flatMap(room => [room.x, room.y]);
-        const path = new Konva.Line({
-            points,
-            stroke: 'green',
-            strokeWidth: 0.1
-        })
-        this.overlayLayer.add(path)
-        this.paths.push(path)
-        return path
+            .filter((room): room is MapData.Room => room !== undefined);
+
+        const segments: number[][] = [];
+        let currentSegment: number[] | null = null;
+
+        const finalizeSegment = () => {
+            if (!currentSegment) {
+                return;
+            }
+            if (currentSegment.length < 4) {
+                segments.pop();
+            }
+            currentSegment = null;
+        };
+
+        const ensureSegment = () => {
+            if (!currentSegment) {
+                currentSegment = [];
+                segments.push(currentSegment);
+            }
+            return currentSegment;
+        };
+
+        rooms.forEach((room, index) => {
+            if (!this.isRoomVisible(room)) {
+                return;
+            }
+
+            const previousRoom = index > 0 ? rooms[index - 1] : undefined;
+            const nextRoom = index < rooms.length - 1 ? rooms[index + 1] : undefined;
+            const previousVisible = this.isRoomVisible(previousRoom);
+
+            if (!previousVisible) {
+                finalizeSegment();
+                const segment = ensureSegment();
+                if (previousRoom) {
+                    const directionToPrevious = this.getDirectionTowards(room, previousRoom);
+                    if (directionToPrevious) {
+                        const startPoint = movePoint(room.x, room.y, directionToPrevious, Settings.roomSize);
+                        segment.push(startPoint.x, startPoint.y);
+                    }
+                }
+            } else {
+                ensureSegment();
+            }
+
+            currentSegment?.push(room.x, room.y);
+
+            const nextVisible = this.isRoomVisible(nextRoom);
+            if (!nextVisible && nextRoom) {
+                const directionToNext = this.getDirectionTowards(room, nextRoom);
+                if (directionToNext) {
+                    const endPoint = movePoint(room.x, room.y, directionToNext, Settings.roomSize);
+                    currentSegment?.push(endPoint.x, endPoint.y);
+                }
+                finalizeSegment();
+            }
+        });
+
+        finalizeSegment();
+
+        const paths = segments
+            .filter(points => points.length >= 4)
+            .map(points => new Konva.Line({
+                points,
+                stroke: 'green',
+                strokeWidth: 0.1
+            }));
+
+        paths.forEach(path => {
+            this.overlayLayer.add(path);
+            this.paths.push(path);
+        });
+
+        return paths[0];
     }
 
     clearPaths() {
@@ -158,6 +233,29 @@ export class Renderer {
             path.destroy()
         })
         this.paths = []
+    }
+
+    private isRoomVisible(room?: MapData.Room) {
+        if (!room) {
+            return false;
+        }
+        return room.area === this.currentArea && room.z === this.currentZIndex;
+    }
+
+    private getDirectionTowards(from: MapData.Room, to: MapData.Room): PlanarDirection | undefined {
+        for (const direction of planarDirections) {
+            if (from.exits[direction] === to.id) {
+                return direction;
+            }
+        }
+
+        for (const direction of planarDirections) {
+            if (to.exits[direction] === from.id) {
+                return oppositeDirections[direction];
+            }
+        }
+
+        return undefined;
     }
 
     private centerOnRoom(room: MapData.Room, instant: boolean = false) {

--- a/src/directions.ts
+++ b/src/directions.ts
@@ -1,0 +1,66 @@
+export type PlanarDirection =
+    | "north"
+    | "south"
+    | "east"
+    | "west"
+    | "northeast"
+    | "northwest"
+    | "southeast"
+    | "southwest";
+
+const planarDirectionOffsets: Record<PlanarDirection, {x: number; y: number}> = {
+    north: {x: 0, y: -1},
+    south: {x: 0, y: 1},
+    east: {x: 1, y: 0},
+    west: {x: -1, y: 0},
+    northeast: {x: 1, y: -1},
+    northwest: {x: -1, y: -1},
+    southeast: {x: 1, y: 1},
+    southwest: {x: -1, y: 1},
+};
+
+export const planarDirections: PlanarDirection[] = [
+    "north",
+    "south",
+    "east",
+    "west",
+    "northeast",
+    "northwest",
+    "southeast",
+    "southwest",
+];
+
+export const oppositeDirections: Record<PlanarDirection, PlanarDirection> = {
+    north: "south",
+    south: "north",
+    east: "west",
+    west: "east",
+    northeast: "southwest",
+    northwest: "southeast",
+    southeast: "northwest",
+    southwest: "northeast",
+};
+
+function isPlanarDirection(direction: MapData.direction | undefined): direction is PlanarDirection {
+    if (!direction) {
+        return false;
+    }
+    return Object.prototype.hasOwnProperty.call(planarDirectionOffsets, direction);
+}
+
+export function movePoint(
+    x: number,
+    y: number,
+    direction?: MapData.direction,
+    distance: number = 1,
+) {
+    if (!isPlanarDirection(direction)) {
+        return {x, y};
+    }
+
+    const offset = planarDirectionOffsets[direction];
+    return {
+        x: x + offset.x * distance,
+        y: y + offset.y * distance,
+    };
+}


### PR DESCRIPTION
## Summary
- extract shared planar direction helpers into a new module
- update Renderer to consume the shared helpers when extending path segments
- reuse the shared movePoint utility throughout ExitRenderer and fix the locked door color literal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfc3a89e84832a922e6753cab82770