### PR TITLE
Track exploration area changes to trigger renderer redraw

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -33,7 +33,41 @@
             border-radius: 0.5rem;
             font-size: 0.9rem;
             line-height: 1.4;
-            pointer-events: none;
+            pointer-events: auto;
+        }
+
+        #controls {
+            margin-top: 0.5rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        #controls label {
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+            font-weight: 500;
+        }
+
+        #destination-form {
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+        }
+
+        #destination-inputs {
+            display: flex;
+            gap: 0.35rem;
+        }
+
+        #destination-input {
+            width: 6rem;
+        }
+
+        #destination-status {
+            font-size: 0.8rem;
+            color: #c8f7ff;
         }
 
         #hud strong {
@@ -47,6 +81,21 @@
 <div id="hud">
     <div id="status">Loading map…</div>
     <div id="walker-status"></div>
+    <div id="controls">
+        <label>
+            <input type="checkbox" id="exploration-toggle" checked>
+            Exploration overlay
+        </label>
+        <form id="destination-form">
+            <label for="destination-input">Destination room</label>
+            <div id="destination-inputs">
+                <input type="number" id="destination-input" min="1" placeholder="Room ID" />
+                <button type="submit">Set</button>
+                <button type="button" id="destination-clear">Clear</button>
+            </div>
+            <div id="destination-status"></div>
+        </form>
+    </div>
 </div>
 <script type="module" src="/main.ts"></script>
 </body>

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -97,10 +97,6 @@ function walkStep() {
 
     currentRoomId = nextRoom.id;
 
-    if (newlyVisited) {
-        renderer.drawArea(nextRoom.area, nextRoom.z);
-    }
-
     renderer.setPosition(nextRoom.id);
     updateAreaStatus(nextRoom.area);
 

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -20,7 +20,7 @@ const visitedRooms = mapReader.decorateWithExploration([startingRoomId]);
 const renderer = new Renderer(stageElement, mapReader);
 const startingRoom = mapReader.getRoom(startingRoomId);
 let currentRoomId = startingRoomId;
-let walkerTimeout: number | undefined;
+const walkerState: { timeoutId: number | undefined } = { timeoutId: undefined };
 let destinationRoomId: number | undefined;
 let currentDestinationPath: number[] | undefined;
 
@@ -131,10 +131,8 @@ function pickNextRoom(room: MapData.Room) {
         return !visitedRooms?.has(candidate.id);
     });
 
-    const choices = unvisited.length ? unvisited : exits;
-
     const preferredRoomId = getNextStepTowardsDestination(room.id);
-    const preferredRoom = preferredRoomId ? choices.find(candidate => candidate.id === preferredRoomId) : undefined;
+    const preferredRoom = preferredRoomId ? exits.find(candidate => candidate.id === preferredRoomId) : undefined;
 
     if (preferredRoom) {
         const bias = unvisited.length ? 0.75 : 0.55;
@@ -143,14 +141,17 @@ function pickNextRoom(room: MapData.Room) {
         }
     }
 
+    const choices = unvisited.length ? unvisited : exits;
+
     return choices[Math.floor(Math.random() * choices.length)];
 }
 
 function scheduleNextStep(delay = randomDelay()) {
-    if (walkerTimeout) {
-        window.clearTimeout(walkerTimeout);
+    const {timeoutId} = walkerState;
+    if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
     }
-    walkerTimeout = window.setTimeout(walkStep, delay);
+    walkerState.timeoutId = window.setTimeout(walkStep, delay);
     walkerStatusElement.textContent = `Next step in ${(delay / 1000).toFixed(1)}s`;
 }
 

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -15,6 +15,7 @@ mapReader.decorateWithExploration([startingRoomId]);
 const renderer = new Renderer(stageElement, mapReader);
 const startingRoom = mapReader.getRoom(startingRoomId);
 let currentRoomId = startingRoomId;
+let walkerTimeout: number | undefined;
 
 if (startingRoom) {
     const startingArea = mapReader.getExplorationArea(startingRoom.area);
@@ -67,8 +68,6 @@ function pickNextRoom(room: MapData.Room) {
     const choices = unvisited.length ? unvisited : exits;
     return choices[Math.floor(Math.random() * choices.length)];
 }
-
-let walkerTimeout: number | undefined;
 
 function scheduleNextStep(delay = randomDelay()) {
     if (walkerTimeout) {

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -6,16 +6,23 @@ import MapReader from "@src/reader/MapReader";
 const stageElement = document.getElementById("stage") as HTMLDivElement;
 const statusElement = document.getElementById("status") as HTMLDivElement;
 const walkerStatusElement = document.getElementById("walker-status") as HTMLDivElement;
+const explorationToggle = document.getElementById("exploration-toggle") as HTMLInputElement | null;
+const destinationForm = document.getElementById("destination-form") as HTMLFormElement | null;
+const destinationInput = document.getElementById("destination-input") as HTMLInputElement | null;
+const destinationClearButton = document.getElementById("destination-clear") as HTMLButtonElement | null;
+const destinationStatusElement = document.getElementById("destination-status") as HTMLDivElement | null;
 
 const mapReader = new MapReader(data as MapData.Map, colors as MapData.Env[]);
 const startingRoomId = 1;
 
-mapReader.decorateWithExploration([startingRoomId]);
+const visitedRooms = mapReader.decorateWithExploration([startingRoomId]);
 
 const renderer = new Renderer(stageElement, mapReader);
 const startingRoom = mapReader.getRoom(startingRoomId);
 let currentRoomId = startingRoomId;
 let walkerTimeout: number | undefined;
+let destinationRoomId: number | undefined;
+let currentDestinationPath: number[] | undefined;
 
 if (startingRoom) {
     const startingArea = mapReader.getExplorationArea(startingRoom.area);
@@ -23,6 +30,7 @@ if (startingRoom) {
 
     renderer.setPosition(startingRoomId);
     updateAreaStatus(startingRoom.area);
+    updateDestinationStatus("No destination set.");
 
     walkerStatusElement.textContent = "Walker preparing first step…";
     scheduleNextStep(600);
@@ -31,11 +39,66 @@ if (startingRoom) {
     walkerStatusElement.textContent = "Walker is idle.";
 }
 
+explorationToggle?.addEventListener("change", () => {
+    if (explorationToggle.checked) {
+        mapReader.decorateWithExploration(visitedRooms);
+    } else {
+        mapReader.clearExplorationDecoration();
+    }
+    renderer.setPosition(currentRoomId);
+    const currentRoom = mapReader.getRoom(currentRoomId);
+    if (currentRoom) {
+        updateAreaStatus(currentRoom.area);
+    }
+    updateDestinationGuidance();
+});
+
+if (explorationToggle) {
+    explorationToggle.checked = mapReader.isExplorationEnabled();
+}
+
+destinationForm?.addEventListener("submit", event => {
+    event.preventDefault();
+    if (!destinationInput) {
+        return;
+    }
+    const roomId = Number.parseInt(destinationInput.value, 10);
+    if (Number.isNaN(roomId)) {
+        updateDestinationStatus("Enter a valid room id.");
+        return;
+    }
+
+    const room = mapReader.getRoom(roomId);
+    if (!room) {
+        updateDestinationStatus(`Room ${roomId} not found.`);
+        return;
+    }
+
+    destinationRoomId = roomId;
+    destinationInput.value = roomId.toString();
+    updateDestinationGuidance();
+});
+
+destinationClearButton?.addEventListener("click", () => {
+    destinationRoomId = undefined;
+    currentDestinationPath = undefined;
+    updateDestinationStatus("Destination cleared. Walking freely.");
+    renderer.clearPaths();
+    if (destinationInput) {
+        destinationInput.value = "";
+    }
+});
+
 function getRoomExits(room: MapData.Room) {
     return Object.values(room.exits).filter((exitId): exitId is number => typeof exitId === "number" && exitId > 0);
 }
 
 function updateAreaStatus(areaId: number) {
+    if (!mapReader.isExplorationEnabled()) {
+        statusElement.textContent = `Area ${areaId}`;
+        return;
+    }
+
     const area = mapReader.getExplorationArea(areaId);
     if (!area) {
         statusElement.textContent = `Area ${areaId}`;
@@ -62,10 +125,24 @@ function pickNextRoom(room: MapData.Room) {
 
     const unvisited = exits.filter(candidate => {
         const area = mapReader.getExplorationArea(candidate.area);
-        return !area?.hasVisitedRoom(candidate.id);
+        if (area) {
+            return !area.hasVisitedRoom(candidate.id);
+        }
+        return !visitedRooms?.has(candidate.id);
     });
 
     const choices = unvisited.length ? unvisited : exits;
+
+    const preferredRoomId = getNextStepTowardsDestination(room.id);
+    const preferredRoom = preferredRoomId ? choices.find(candidate => candidate.id === preferredRoomId) : undefined;
+
+    if (preferredRoom) {
+        const bias = unvisited.length ? 0.75 : 0.55;
+        if (Math.random() < bias) {
+            return preferredRoom;
+        }
+    }
+
     return choices[Math.floor(Math.random() * choices.length)];
 }
 
@@ -92,13 +169,130 @@ function walkStep() {
     }
 
     const explorationArea = mapReader.getExplorationArea(nextRoom.area);
-    const newlyVisited = explorationArea?.addVisitedRoom(nextRoom.id) ?? false;
+    if (explorationArea) {
+        explorationArea.addVisitedRoom(nextRoom.id);
+    } else {
+        visitedRooms?.add(nextRoom.id);
+    }
 
     currentRoomId = nextRoom.id;
 
     renderer.setPosition(nextRoom.id);
     updateAreaStatus(nextRoom.area);
+    updateDestinationGuidance();
 
     walkerStatusElement.textContent = `Walker moved to room ${nextRoom.id}`;
     scheduleNextStep();
+}
+
+function getNextStepTowardsDestination(fromRoomId: number) {
+    if (!destinationRoomId || destinationRoomId === fromRoomId) {
+        return undefined;
+    }
+    if (currentDestinationPath && currentDestinationPath[0] === fromRoomId) {
+        if (currentDestinationPath.length >= 2) {
+            return currentDestinationPath[1];
+        }
+        return undefined;
+    }
+    const path = findPathBetweenRooms(fromRoomId, destinationRoomId);
+    if (!path || path.length < 2) {
+        return undefined;
+    }
+    currentDestinationPath = path;
+    return path[1];
+}
+
+function findPathBetweenRooms(startRoomId: number, targetRoomId: number) {
+    const startRoom = mapReader.getRoom(startRoomId);
+    const targetRoom = mapReader.getRoom(targetRoomId);
+    if (!startRoom || !targetRoom) {
+        return undefined;
+    }
+
+    if (startRoomId === targetRoomId) {
+        return [startRoomId];
+    }
+
+    const queue: number[] = [startRoomId];
+    const visited = new Set<number>([startRoomId]);
+    const parents = new Map<number, number>();
+
+    while (queue.length) {
+        const currentId = queue.shift();
+        if (currentId === undefined) {
+            break;
+        }
+        const currentRoom = mapReader.getRoom(currentId);
+        if (!currentRoom) {
+            continue;
+        }
+
+        for (const neighborId of getRoomExits(currentRoom)) {
+            if (visited.has(neighborId)) {
+                continue;
+            }
+            visited.add(neighborId);
+            parents.set(neighborId, currentId);
+
+            if (neighborId === targetRoomId) {
+                return buildPathFromParents(targetRoomId, parents, startRoomId);
+            }
+
+            queue.push(neighborId);
+        }
+    }
+
+    return undefined;
+}
+
+function buildPathFromParents(targetId: number, parents: Map<number, number>, startId: number) {
+    const path = [targetId];
+    let current = targetId;
+
+    while (current !== startId) {
+        const parent = parents.get(current);
+        if (parent === undefined) {
+            return undefined;
+        }
+        path.push(parent);
+        current = parent;
+    }
+
+    path.reverse();
+    return path;
+}
+
+function updateDestinationStatus(message: string) {
+    if (!destinationStatusElement) {
+        return;
+    }
+    destinationStatusElement.textContent = message;
+}
+
+function updateDestinationGuidance() {
+    if (!destinationRoomId) {
+        updateDestinationStatus("No destination set.");
+        currentDestinationPath = undefined;
+        return;
+    }
+
+    const path = findPathBetweenRooms(currentRoomId, destinationRoomId);
+    renderer.clearPaths();
+
+    if (!path) {
+        updateDestinationStatus(`No route to room ${destinationRoomId}. Wandering randomly.`);
+        currentDestinationPath = undefined;
+        return;
+    }
+
+    if (path.length < 2) {
+        updateDestinationStatus(`Already at destination room ${destinationRoomId}.`);
+        currentDestinationPath = path;
+        return;
+    }
+
+    renderer.renderPath(path);
+    updateDestinationStatus(`Biasing towards room ${destinationRoomId} (${path.length - 1} steps away).`);
+    currentDestinationPath = path;
 }

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -129,6 +129,7 @@ export class Renderer {
         this.renderRooms(plane.getRooms() ?? []);
         this.renderExits(area.getLinkExits(zIndex));
         this.refreshHighlights();
+        this.stage.batchDraw();
     }
 
     setPosition(roomId: number) {

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -34,6 +34,7 @@ export class Renderer {
     private highlights: Map<number, HighlightData> = new Map();
     private currentArea?: number;
     private currentZIndex?: number;
+    private currentAreaVersion?: number;
     private positionRender?: Konva.Circle;
     private currentTransition?: Konva.Tween;
 
@@ -106,12 +107,16 @@ export class Renderer {
 
     drawArea(id: number, zIndex: number) {
         const area = this.mapReader.getArea(id);
-        const plane = area?.getPlane(zIndex);
+        if (!area) {
+            return;
+        }
+        const plane = area.getPlane(zIndex);
         if (!plane) {
             return;
         }
         this.currentArea = id;
         this.currentZIndex = zIndex;
+        this.currentAreaVersion = area.getVersion();
         this.roomLayer.destroyChildren();
         this.linkLayer.destroyChildren();
 
@@ -129,8 +134,10 @@ export class Renderer {
     setPosition(roomId: number) {
         const room = this.mapReader.getRoom(roomId);
         if (!room) return;
+        const area = this.mapReader.getArea(room.area);
+        const areaVersion = area?.getVersion();
         let instant = false
-        if (this.currentArea !== room.area || this.currentZIndex !== room.z) {
+        if (this.currentArea !== room.area || this.currentZIndex !== room.z || (areaVersion !== undefined && this.currentAreaVersion !== areaVersion)) {
             this.drawArea(room.area, room.z);
             instant = true
         }

--- a/src/reader/Area.ts
+++ b/src/reader/Area.ts
@@ -7,11 +7,20 @@ export default class Area {
     private readonly planes: Record<number, Plane> = {};
     private readonly area: MapData.Area;
     private readonly exits: Map<string, Exit> = new Map();
+    private version = 0;
 
     constructor(area: MapData.Area) {
         this.area = area;
         this.planes = this.createPlanes();
         this.createExits();
+    }
+
+    getVersion() {
+        return this.version;
+    }
+
+    protected markDirty() {
+        this.version++;
     }
 
     getPlane(zIndex: number) {

--- a/src/reader/ExplorationArea.ts
+++ b/src/reader/ExplorationArea.ts
@@ -107,7 +107,11 @@ export default class ExplorationArea extends Area {
     addVisitedRoom(roomId: number) {
         const wasVisited = this.visitedRooms.has(roomId);
         this.visitedRooms.add(roomId);
-        return !wasVisited && this.areaRoomIds.has(roomId);
+        const newlyVisited = !wasVisited && this.areaRoomIds.has(roomId);
+        if (newlyVisited) {
+            this.markDirty();
+        }
+        return newlyVisited;
     }
 
     addVisitedRooms(roomIds: Iterable<number>) {
@@ -118,6 +122,9 @@ export default class ExplorationArea extends Area {
             if (!wasVisited && this.areaRoomIds.has(roomId)) {
                 newlyVisited++;
             }
+        }
+        if (newlyVisited > 0) {
+            this.markDirty();
         }
         return newlyVisited;
     }

--- a/src/reader/MapReader.ts
+++ b/src/reader/MapReader.ts
@@ -32,6 +32,7 @@ export default class MapReader {
     private areas: Record<number, Area> = {};
     private areaSources: Record<number, MapData.Area> = {};
     private visitedRooms?: Set<number>;
+    private explorationEnabled = false;
     private colors: Record<number, Color> = {};
 
     constructor(map: MapData.Map, envs: MapData.Env[]) {
@@ -83,13 +84,26 @@ export default class MapReader {
         this.visitedRooms = visitedRooms instanceof Set ? visitedRooms : new Set(visitedRooms ?? []);
         Object.entries(this.areaSources).forEach(([id, area]) => {
             const numericId = parseInt(id, 10);
-            this.areas[numericId] = new ExplorationArea(area, this.visitedRooms);
+            this.areas[numericId] = new ExplorationArea(area, this.visitedRooms!);
         });
+        this.explorationEnabled = true;
         return this.visitedRooms;
     }
 
     getVisitedRooms() {
         return this.visitedRooms;
+    }
+
+    clearExplorationDecoration() {
+        Object.entries(this.areaSources).forEach(([id, area]) => {
+            const numericId = parseInt(id, 10);
+            this.areas[numericId] = new Area(area);
+        });
+        this.explorationEnabled = false;
+    }
+
+    isExplorationEnabled() {
+        return this.explorationEnabled;
     }
 
     getColorValue(envId: number): string {


### PR DESCRIPTION
## Summary
- add a version counter to areas and bump it whenever exploration visits change
- store the current area version in the renderer so it can redraw when the data changes

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68e013199fe4832a95f0534edf352bce