### PR TITLE
Improve walker BFS preference

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -53,11 +53,6 @@ function randomDelay() {
 const PREFERRED_PATH_PROBABILITY = 0.7;
 
 function findPreferredRoomId(room: MapData.Room) {
-    const visitedRooms = mapReader.getVisitedRooms();
-    if (!visitedRooms) {
-        return undefined;
-    }
-
     const queue: number[] = [room.id];
     const cameFrom = new Map<number, number | null>([[room.id, null]]);
 
@@ -68,8 +63,10 @@ function findPreferredRoomId(room: MapData.Room) {
             continue;
         }
 
+        const area = mapReader.getExplorationArea(currentRoom.area);
+        const isVisited = area?.hasVisitedRoom(currentId) ?? false;
         const isStartRoom = currentId === room.id;
-        if (!visitedRooms.has(currentId) && !isStartRoom) {
+        if (!isVisited && !isStartRoom) {
             let stepId = currentId;
             let parentId = cameFrom.get(stepId) ?? null;
             while (parentId !== null && parentId !== room.id) {


### PR DESCRIPTION
## Summary
- add BFS-based preferred path selection for the demo walker
- ensure the bias towards the BFS step considers all exits before falling back to random exploration
- retain random exploration preference for unvisited rooms when no biased step is taken

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01c2146d0832abea62f44e182cadc