### PR TITLE
Add exit recolor strategies and performance tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dev": "vite",
     "build": "tsc -p tsconfig.json && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "demo:dev": "vite --config vite.demo.config.ts",
     "demo:build": "vite build --config vite.demo.config.ts",
     "demo:preview": "vite preview --config vite.demo.config.ts"
@@ -27,12 +28,13 @@
     "node-dijkstra": "^2.5.1"
   },
   "devDependencies": {
+    "@types/node-dijkstra": "^2.5.6",
     "tslib": "^2.8.1",
     "tsx": "^4.19.1",
     "typescript": "^5.6.3",
     "vite": "^5.4.8",
     "vite-plugin-dts": "^4.3.0",
-    "@types/node-dijkstra": "^2.5.6"
+    "vitest": "^2.1.4"
   },
   "files": [
     "dist"

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -238,6 +238,7 @@ export class Renderer {
         this.currentAreaInstance = area;
         this.currentZIndex = zIndex;
         this.currentAreaVersion = area.getVersion();
+        this.exitRenderer.clearExitCache();
         this.roomLayer.destroyChildren();
         this.linkLayer.destroyChildren();
 
@@ -262,6 +263,22 @@ export class Renderer {
         };
         const event = new CustomEvent<RoomContextMenuEventDetail>('roomcontextmenu', {detail});
         container.dispatchEvent(event);
+    }
+
+    setDirectionalExitColorByReference(roomId: number, direction: MapData.direction, color: string) {
+        return this.exitRenderer.setDirectionalExitColorByReference(roomId, direction, color);
+    }
+
+    setDirectionalExitColorByName(roomId: number, direction: MapData.direction, color: string) {
+        return this.exitRenderer.setDirectionalExitColorByName(this.linkLayer, roomId, direction, color);
+    }
+
+    setSpecialExitColorByReference(roomId: number, exitId: string, color: string) {
+        return this.exitRenderer.setSpecialExitColorByReference(roomId, exitId, color);
+    }
+
+    setSpecialExitColorByName(roomId: number, exitId: string, color: string) {
+        return this.exitRenderer.setSpecialExitColorByName(this.linkLayer, roomId, exitId, color);
     }
 
     private emitZoomChangeEvent() {

--- a/tests/exitColorStrategies.test.ts
+++ b/tests/exitColorStrategies.test.ts
@@ -1,0 +1,318 @@
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+vi.mock("konva", () => {
+    class Node {
+        protected _name = "";
+        protected _layer?: Layer;
+        protected _children: Node[] = [];
+
+        addName(name: string) {
+            const names = new Set(this._name.split(/\s+/).filter(Boolean));
+            names.add(name);
+            this._name = Array.from(names).join(" ");
+            return this;
+        }
+
+        name(value?: string) {
+            if (value === undefined) {
+                return this._name;
+            }
+            this._name = value;
+            return this;
+        }
+
+        getLayer() {
+            return this._layer;
+        }
+
+        setLayer(layer?: Layer) {
+            this._layer = layer;
+        }
+
+        getChildren() {
+            return this._children;
+        }
+
+        protected matchesSelector(selector: string) {
+            if (selector.startsWith(".")) {
+                const name = selector.slice(1);
+                return this._name.split(/\s+/).includes(name);
+            }
+            return this.constructor.name === selector;
+        }
+
+        findOne(selector: string): Node | null {
+            return this.matchesSelector(selector) ? this : null;
+        }
+    }
+
+    class Shape extends Node {
+        protected _stroke?: string;
+        protected _fill?: string;
+
+        constructor(config: {stroke?: string; fill?: string} = {}) {
+            super();
+            this._stroke = config.stroke;
+            this._fill = config.fill;
+        }
+
+        stroke(value?: string) {
+            if (value === undefined) {
+                return this._stroke;
+            }
+            this._stroke = value;
+            return this;
+        }
+
+        fill(value?: string) {
+            if (value === undefined) {
+                return this._fill;
+            }
+            this._fill = value;
+            return this;
+        }
+
+        dash() {
+            return this;
+        }
+
+        dashOffset() {
+            return this;
+        }
+    }
+
+    class Group extends Node {
+        add(node: Node) {
+            this._children.push(node);
+            node.setLayer(this._layer);
+        }
+
+        setLayer(layer?: Layer) {
+            super.setLayer(layer);
+            this._children.forEach(child => child.setLayer(layer));
+        }
+
+        findOne(selector: string): Node | null {
+            if (this.matchesSelector(selector)) {
+                return this;
+            }
+            for (const child of this._children) {
+                const match = child.findOne(selector);
+                if (match) {
+                    return match;
+                }
+            }
+            return null;
+        }
+    }
+
+    class Layer extends Group {
+        destroyChildren() {
+            this._children.forEach(child => child.setLayer(undefined));
+            this._children = [];
+        }
+
+        batchDraw() {
+            return this;
+        }
+    }
+
+    class Line extends Shape {
+        constructor(config: {stroke?: string; fill?: string} = {}) {
+            super(config);
+        }
+    }
+
+    class Arrow extends Line {}
+
+    class Rect extends Shape {}
+
+    class RegularPolygon extends Shape {
+        rotation() {
+            return this;
+        }
+
+        position() {
+            return this;
+        }
+
+        clone() {
+            const clone = new RegularPolygon();
+            clone.stroke(this.stroke());
+            clone.fill(this.fill());
+            return clone;
+        }
+
+        scaleX() {
+            return this;
+        }
+
+        scaleY() {
+            return this;
+        }
+    }
+
+    return {
+        default: {
+            Node,
+            Group,
+            Layer,
+            Line,
+            Arrow,
+            Rect,
+            RegularPolygon,
+        },
+    };
+});
+
+import Konva from "konva";
+import ExitRenderer from "../src/ExitRenderer";
+import type Exit from "../src/reader/Exit";
+import type MapReader from "../src/reader/MapReader";
+import {Settings} from "../src/Renderer";
+import {performance} from "node:perf_hooks";
+
+type RoomInit = {
+    id: number;
+    area?: number;
+    env?: number;
+    x?: number;
+    y?: number;
+    z?: number;
+};
+
+type StubRoom = ReturnType<typeof createRoom>;
+
+type StubMapReader = Pick<MapReader, "getRoom" | "getColorValue" | "getSymbolColor">;
+
+function createRoom({id, area = 1, env = 1, x = 0, y = 0, z = 0}: RoomInit): StubRoom {
+    return {
+        id,
+        area,
+        x,
+        y,
+        z,
+        areaId: `${area}`,
+        weight: 1,
+        roomChar: "",
+        name: `Room ${id}`,
+        userData: {},
+        customLines: {},
+        stubs: [],
+        hash: `room-${id}`,
+        env,
+        exits: {} as Record<string, number>,
+        doors: {},
+        specialExits: {},
+    };
+}
+
+describe("ExitRenderer color strategies", () => {
+    let rooms: Map<number, StubRoom>;
+    let mapReader: StubMapReader;
+    let renderer: ExitRenderer;
+    let layer: Konva.Layer;
+
+    beforeEach(() => {
+        Settings.lineColor = "rgb(225, 255, 225)";
+        rooms = new Map();
+        const roomA = createRoom({id: 1, x: 0, y: 0});
+        const roomB = createRoom({id: 2, x: 1, y: 0});
+        rooms.set(roomA.id, roomA);
+        rooms.set(roomB.id, roomB);
+
+        mapReader = {
+            getRoom: (id: number) => rooms.get(id),
+            getColorValue: () => "rgb(255, 0, 0)",
+            getSymbolColor: () => "rgba(255,255,255)",
+        } as StubMapReader;
+
+        renderer = new ExitRenderer(mapReader as MapReader);
+        layer = new Konva.Layer();
+    });
+
+    function renderTwoWayExit() {
+        const exit: Exit = {
+            a: 1,
+            b: 2,
+            aDir: "east",
+            bDir: "west",
+            zIndex: [0],
+        };
+        const node = renderer.render(exit);
+        expect(node).toBeDefined();
+        layer.add(node!);
+        return node!;
+    }
+
+    it("updates directional exits via cached references", () => {
+        const node = renderTwoWayExit();
+        const result = renderer.setDirectionalExitColorByReference(1, "east", "#123456");
+        expect(result).toBe(true);
+        const line = node.findOne("Line") as Konva.Line;
+        expect(line.stroke()).toBe("#123456");
+    });
+
+    it("updates directional exits via node names", () => {
+        renderTwoWayExit();
+        const updated = renderer.setDirectionalExitColorByName(layer, 1, "east", "#654321");
+        expect(updated).toBe(true);
+        const group = layer.findOne(".exit-1-direction:east") as Konva.Group;
+        const line = group.findOne("Line") as Konva.Line;
+        expect(line.stroke()).toBe("#654321");
+    });
+
+    it("updates special exits with both strategies", () => {
+        const room = rooms.get(1)!;
+        room.customLines = {
+            link: {
+                points: [{x: 0.5, y: 0}],
+                attributes: {
+                    color: {r: 100, g: 150, b: 200, alpha: 1},
+                    style: "solid line",
+                    arrow: true,
+                },
+            },
+        };
+        const renders = renderer.renderSpecialExits(room);
+        renders.forEach(node => layer.add(node));
+
+        const refUpdated = renderer.setSpecialExitColorByReference(1, "link", "#abcdef");
+        expect(refUpdated).toBe(true);
+        const byRef = layer.findOne(".exit-1-special:link") as Konva.Node;
+        expect((byRef as Konva.Arrow).stroke()).toBe("#abcdef");
+        expect((byRef as Konva.Arrow).fill()).toBe("#abcdef");
+
+        const nameUpdated = renderer.setSpecialExitColorByName(layer, 1, "link", "#fedcba");
+        expect(nameUpdated).toBe(true);
+        const byName = layer.findOne(".exit-1-special:link") as Konva.Arrow;
+        expect(byName.stroke()).toBe("#fedcba");
+        expect(byName.fill()).toBe("#fedcba");
+    });
+
+    it("performs faster with cached references", () => {
+        renderTwoWayExit();
+
+        const iterations = 2000;
+        const colors = Array.from({length: iterations}, (_, index) => {
+            const channel = (index % 256).toString(16).padStart(2, "0");
+            return `#${channel}ff33`;
+        });
+
+        const referenceStart = performance.now();
+        colors.forEach(color => {
+            const ok = renderer.setDirectionalExitColorByReference(1, "east", color);
+            if (!ok) throw new Error("reference update failed");
+        });
+        const referenceTime = performance.now() - referenceStart;
+
+        const nameStart = performance.now();
+        colors.forEach(color => {
+            const ok = renderer.setDirectionalExitColorByName(layer, 1, "east", color);
+            if (!ok) throw new Error("name update failed");
+        });
+        const nameTime = performance.now() - nameStart;
+
+        expect(referenceTime).toBeLessThan(nameTime);
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+    root: __dirname,
+    test: {
+        include: ["tests/**/*.test.ts"],
+        environment: "node",
+    },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -512,6 +512,65 @@
   resolved "https://registry.yarnpkg.com/@types/node-dijkstra/-/node-dijkstra-2.5.6.tgz#df4621e50df10b2e98229796ab1c2a3ca74b65b8"
   integrity sha512-+n0D+FdGuCLsKoH7fwX3iWfkKSAG0e4z1F96UG5gAnlE2V/1AZO6LuPLzHQd1MC2fZJDcE2cpTS2Ln1lywgUvw==
 
+"@vitest/expect@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-2.1.9.tgz#b566ea20d58ea6578d8dc37040d6c1a47ebe5ff8"
+  integrity sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==
+  dependencies:
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    tinyrainbow "^1.2.0"
+
+"@vitest/mocker@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-2.1.9.tgz#36243b27351ca8f4d0bbc4ef91594ffd2dc25ef5"
+  integrity sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==
+  dependencies:
+    "@vitest/spy" "2.1.9"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.12"
+
+"@vitest/pretty-format@2.1.9", "@vitest/pretty-format@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-2.1.9.tgz#434ff2f7611689f9ce70cd7d567eceb883653fdf"
+  integrity sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==
+  dependencies:
+    tinyrainbow "^1.2.0"
+
+"@vitest/runner@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-2.1.9.tgz#cc18148d2d797fd1fd5908d1f1851d01459be2f6"
+  integrity sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==
+  dependencies:
+    "@vitest/utils" "2.1.9"
+    pathe "^1.1.2"
+
+"@vitest/snapshot@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-2.1.9.tgz#24260b93f798afb102e2dcbd7e61c6dfa118df91"
+  integrity sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+
+"@vitest/spy@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-2.1.9.tgz#cb28538c5039d09818b8bfa8edb4043c94727c60"
+  integrity sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==
+  dependencies:
+    tinyspy "^3.0.2"
+
+"@vitest/utils@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-2.1.9.tgz#4f2486de8a54acf7ecbf2c5c24ad7994a680a6c1"
+  integrity sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
+    loupe "^3.1.2"
+    tinyrainbow "^1.2.0"
+
 "@volar/language-core@2.4.23", "@volar/language-core@~2.4.11":
   version "2.4.23"
   resolved "https://registry.yarnpkg.com/@volar/language-core/-/language-core-2.4.23.tgz#deb6dbc5fdbafa9bb7ba691fc59cb196cdb856d3"
@@ -638,6 +697,11 @@ argparse@~1.0.9:
   dependencies:
     sprintf-js "~1.0.2"
 
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -649,6 +713,27 @@ brace-expansion@^2.0.1:
   integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
   dependencies:
     balanced-match "^1.0.0"
+
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
+chai@^5.1.2:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.3.3.tgz#dd3da955e270916a4bd3f625f4b919996ada7e06"
+  integrity sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
+
+check-error@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
+  integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
 
 compare-versions@^6.1.1:
   version "6.1.1"
@@ -670,17 +755,27 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
 
-debug@^4.4.0:
+debug@^4.3.7, debug@^4.4.0:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
+
 entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+es-module-lexer@^1.5.4:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
 esbuild@^0.21.3:
   version "0.21.5"
@@ -747,6 +842,18 @@ estree-walker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
+expect-type@^1.1.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.2.tgz#c030a329fb61184126c8447585bc75a7ec6fbff3"
+  integrity sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==
 
 exsolve@^1.0.7:
   version "1.0.7"
@@ -866,6 +973,11 @@ lodash@~4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+loupe@^3.1.0, loupe@^3.1.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
+  integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -873,7 +985,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-magic-string@^0.30.17:
+magic-string@^0.30.12, magic-string@^0.30.17:
   version "0.30.19"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.19.tgz#cebe9f104e565602e5d2098c5f2e79a77cc86da9"
   integrity sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==
@@ -934,10 +1046,20 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+pathe@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
+  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
 pathe@^2.0.1, pathe@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+pathval@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
+  integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
 
 picocolors@^1.1.1:
   version "1.1.1"
@@ -1043,6 +1165,11 @@ semver@~7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -1057,6 +1184,16 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+std-env@^3.8.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
+  integrity sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==
 
 string-argv@~0.3.1:
   version "0.3.2"
@@ -1079,6 +1216,31 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
+tinypool@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
+  integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
+
+tinyrainbow@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-1.2.0.tgz#5c57d2fc0fb3d1afd78465c33ca885d04f02abb5"
+  integrity sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==
+
+tinyspy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
+  integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
 
 tslib@^2.8.1:
   version "2.8.1"
@@ -1122,6 +1284,17 @@ uri-js@^4.2.2, uri-js@^4.4.1:
   dependencies:
     punycode "^2.1.0"
 
+vite-node@2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-2.1.9.tgz#549710f76a643f1c39ef34bdb5493a944e4f895f"
+  integrity sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.7"
+    es-module-lexer "^1.5.4"
+    pathe "^1.1.2"
+    vite "^5.0.0"
+
 vite-plugin-dts@^4.3.0:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/vite-plugin-dts/-/vite-plugin-dts-4.5.4.tgz#51b60aaaa760d9cf5c2bb3676c69d81910d6b08c"
@@ -1137,7 +1310,7 @@ vite-plugin-dts@^4.3.0:
     local-pkg "^1.0.0"
     magic-string "^0.30.17"
 
-vite@^5.4.8:
+vite@^5.0.0, vite@^5.4.8:
   version "5.4.20"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.20.tgz#3267a5e03f21212f44edfd72758138e8fcecd76a"
   integrity sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==
@@ -1148,10 +1321,44 @@ vite@^5.4.8:
   optionalDependencies:
     fsevents "~2.3.3"
 
+vitest@^2.1.4:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-2.1.9.tgz#7d01ffd07a553a51c87170b5e80fea3da7fb41e7"
+  integrity sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==
+  dependencies:
+    "@vitest/expect" "2.1.9"
+    "@vitest/mocker" "2.1.9"
+    "@vitest/pretty-format" "^2.1.9"
+    "@vitest/runner" "2.1.9"
+    "@vitest/snapshot" "2.1.9"
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    debug "^4.3.7"
+    expect-type "^1.1.0"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+    std-env "^3.8.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.1"
+    tinypool "^1.0.1"
+    tinyrainbow "^1.2.0"
+    vite "^5.0.0"
+    vite-node "2.1.9"
+    why-is-node-running "^2.3.0"
+
 vscode-uri@^3.0.8:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.1.0.tgz#dd09ec5a66a38b5c3fffc774015713496d14e09c"
   integrity sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary
- cache directional and special exit nodes so their colors can be updated via stored references or layer lookups
- expose Renderer helpers plus vitest configuration to exercise both recolor strategies
- add a vitest suite with a mocked Konva backend that verifies functionality and compares lookup performance

## Testing
- npx yarn@1 test

------
https://chatgpt.com/codex/tasks/task_e_68e23256e7b8832ab23376626465c6ef