### PR TITLE
Simplify current room highlight toggle

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -114,6 +114,14 @@
             <input type="checkbox" id="exploration-toggle">
             Exploration overlay
         </label>
+        <label>
+            <input type="checkbox" id="instant-move-toggle">
+            Instant map movement
+        </label>
+        <label>
+            <input type="checkbox" id="highlight-toggle">
+            Highlight current room &amp; exits
+        </label>
         <form id="destination-form">
             <label for="destination-input">Destination room</label>
             <div id="destination-inputs">

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,6 +1,6 @@
 import data from "./mapExport.json";
 import colors from "./colors.json";
-import {Renderer} from "@src";
+import {Renderer, Settings} from "@src";
 import type {RoomContextMenuEventDetail} from "@src";
 import MapReader from "@src/reader/MapReader";
 
@@ -11,6 +11,8 @@ const contextMenuElement = document.getElementById("context-menu") as HTMLDivEle
 const contextMenuContent = document.getElementById("context-menu-content") as HTMLDivElement | null;
 const walkerToggleButton = document.getElementById("walker-toggle") as HTMLButtonElement | null;
 const explorationToggle = document.getElementById("exploration-toggle") as HTMLInputElement | null;
+const instantMoveToggle = document.getElementById("instant-move-toggle") as HTMLInputElement | null;
+const highlightToggle = document.getElementById("highlight-toggle") as HTMLInputElement | null;
 const destinationForm = document.getElementById("destination-form") as HTMLFormElement | null;
 const destinationInput = document.getElementById("destination-input") as HTMLInputElement | null;
 const destinationClearButton = document.getElementById("destination-clear") as HTMLButtonElement | null;
@@ -104,6 +106,23 @@ explorationToggle?.addEventListener("change", () => {
 
 if (explorationToggle) {
     explorationToggle.checked = mapReader.isExplorationEnabled();
+}
+
+instantMoveToggle?.addEventListener("change", () => {
+    Settings.instantMapMove = instantMoveToggle.checked;
+});
+
+if (instantMoveToggle) {
+    instantMoveToggle.checked = Settings.instantMapMove;
+}
+
+highlightToggle?.addEventListener("change", () => {
+    Settings.highlightCurrentRoom = highlightToggle.checked;
+    renderer.setPosition(currentRoomId);
+});
+
+if (highlightToggle) {
+    highlightToggle.checked = Settings.highlightCurrentRoom;
 }
 
 destinationForm?.addEventListener("submit", event => {


### PR DESCRIPTION
## Summary
- replace the separate border toggles with a single setting that controls whether the current room and its exits are highlighted
- ensure adjacent rooms in the overlay no longer receive colored borders when the highlight is disabled
- expose renderer settings toggles in the demo so instant movement and current-room highlighting can be switched on the fly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2482e6350832a936881dd8dd06425