### PR TITLE
Fix pinch zoom jump

### DIFF
--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -191,13 +191,14 @@ export class Renderer {
             const stageX = this.stage.x();
             const stageY = this.stage.y();
 
-            const mapPoint1 = {
-                x: (p1.x - stageX) / oldScale,
-                y: (p1.y - stageY) / oldScale,
+            const centerPointer = {
+                x: this.stage.width() / 2,
+                y: this.stage.height() / 2,
             };
-            const mapPoint2 = {
-                x: (p2.x - stageX) / oldScale,
-                y: (p2.y - stageY) / oldScale,
+
+            const centerMapPoint = {
+                x: (centerPointer.x - stageX) / oldScale,
+                y: (centerPointer.y - stageY) / oldScale,
             };
 
             const newZoom = this.currentZoom * (distance / lastPinchDistance);
@@ -205,17 +206,9 @@ export class Renderer {
             const zoomChanged = this.setZoom(newZoom);
 
             const newScale = this.stage.scaleX();
-            const pos1 = {
-                x: p1.x - mapPoint1.x * newScale,
-                y: p1.y - mapPoint1.y * newScale,
-            };
-            const pos2 = {
-                x: p2.x - mapPoint2.x * newScale,
-                y: p2.y - mapPoint2.y * newScale,
-            };
             const newPos = {
-                x: (pos1.x + pos2.x) / 2,
-                y: (pos1.y + pos2.y) / 2,
+                x: centerPointer.x - centerMapPoint.x * newScale,
+                y: centerPointer.y - centerMapPoint.y * newScale,
             };
 
             this.stage.position(newPos);

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -209,11 +209,9 @@ export class Renderer {
             const zoomChanged = this.setZoom(newZoom);
 
             const newScale = this.stage.scaleX();
-            const dx = newCenter.x - lastPinchCenter.x;
-            const dy = newCenter.y - lastPinchCenter.y;
             const newPos = {
-                x: newCenter.x - pointTo.x * newScale + dx,
-                y: newCenter.y - pointTo.y * newScale + dy,
+                x: newCenter.x - pointTo.x * newScale,
+                y: newCenter.y - pointTo.y * newScale,
             };
 
             this.stage.position(newPos);


### PR DESCRIPTION
## Summary
- remove redundant translation offsets when handling pinch zoom so the map no longer jumps on the first move

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2981d4ec8832ab0033c5c10f3f8cc