### PR TITLE
Fix exploration overlay rendering

### DIFF
--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -665,26 +665,6 @@ export class Renderer {
             );
             this.overlayLayer.add(overlayRoom);
             this.currentRoomOverlay.push(overlayRoom);
-
-            if (!isCurrent) {
-                this.exitRenderer.renderSpecialExits(roomToRedraw).forEach(render => {
-                    this.disableListening(render);
-                    this.overlayLayer.add(render);
-                    this.currentRoomOverlay.push(render);
-                });
-
-                this.exitRenderer.renderStubs(roomToRedraw).forEach(render => {
-                    this.disableListening(render);
-                    this.overlayLayer.add(render);
-                    this.currentRoomOverlay.push(render);
-                });
-
-                this.exitRenderer.renderInnerExits(roomToRedraw).forEach(render => {
-                    this.disableListening(render);
-                    this.overlayLayer.add(render);
-                    this.currentRoomOverlay.push(render);
-                });
-            }
         });
 
         postRoomNodes.forEach(node => {

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -3,6 +3,7 @@ import ExitRenderer from "./ExitRenderer";
 import MapReader from "./reader/MapReader";
 import Exit from "./reader/Exit";
 import Area from "./reader/Area";
+import ExplorationArea from "./reader/ExplorationArea";
 import PathRenderer from "./PathRenderer";
 
 const defaultRoomSize = 0.6;
@@ -275,8 +276,8 @@ export class Renderer {
         this.stage.scale({x: defaultZoom * this.currentZoom, y: defaultZoom * this.currentZoom});
 
         this.renderLabels(plane.getLabels());
-        this.renderRooms(plane.getRooms() ?? []);
         this.renderExits(area.getLinkExits(zIndex));
+        this.renderRooms(plane.getRooms() ?? []);
         this.refreshHighlights();
         this.stage.batchDraw();
     }
@@ -595,6 +596,9 @@ export class Renderer {
         const preRoomNodes: Array<Konva.Group | Konva.Shape> = [];
         const postRoomNodes: Array<Konva.Group | Konva.Shape> = [];
 
+        const explorationArea =
+            this.currentAreaInstance instanceof ExplorationArea ? this.currentAreaInstance : undefined;
+
         if (this.currentAreaInstance && this.currentZIndex !== undefined) {
             const exits = this.currentAreaInstance
                 .getLinkExits(this.currentZIndex)
@@ -610,10 +614,14 @@ export class Renderer {
 
                 const otherRoomId = exit.a === room.id ? exit.b : exit.a;
                 const otherRoom = this.mapReader.getRoom(otherRoomId);
+                const canRenderOtherRoom =
+                    !explorationArea || explorationArea.hasVisitedRoom(otherRoomId);
+
                 if (
                     otherRoom &&
                     otherRoom.area === this.currentArea &&
-                    otherRoom.z === this.currentZIndex
+                    otherRoom.z === this.currentZIndex &&
+                    canRenderOtherRoom
                 ) {
                     roomsToRedraw.set(otherRoom.id, otherRoom);
                 }

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -594,7 +594,6 @@ export class Renderer {
         roomsToRedraw.set(room.id, room);
 
         const preRoomNodes: Array<Konva.Group | Konva.Shape> = [];
-        const postRoomNodes: Array<Konva.Group | Konva.Shape> = [];
 
         const explorationArea =
             this.currentAreaInstance instanceof ExplorationArea ? this.currentAreaInstance : undefined;
@@ -643,11 +642,6 @@ export class Renderer {
             preRoomNodes.push(render);
         });
 
-        this.exitRenderer.renderInnerExits(room, highlightColor).forEach(render => {
-            this.disableListening(render);
-            postRoomNodes.push(render);
-        });
-
         preRoomNodes.forEach(node => {
             this.overlayLayer.add(node);
             this.currentRoomOverlay.push(node);
@@ -665,11 +659,13 @@ export class Renderer {
             );
             this.overlayLayer.add(overlayRoom);
             this.currentRoomOverlay.push(overlayRoom);
-        });
 
-        postRoomNodes.forEach(node => {
-            this.overlayLayer.add(node);
-            this.currentRoomOverlay.push(node);
+            const innerExitColor = isCurrent && Settings.highlightCurrentRoom ? currentRoomColor : undefined;
+            this.exitRenderer.renderInnerExits(roomToRedraw, innerExitColor).forEach(render => {
+                this.disableListening(render);
+                this.overlayLayer.add(render);
+                this.currentRoomOverlay.push(render);
+            });
         });
 
         this.overlayLayer.batchDraw();


### PR DESCRIPTION
## Summary
- avoid drawing adjacent rooms in the current-room overlay when exploration mode hides them
- render link elements before rooms so rooms appear on top of links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2a6222558832a9c77b24b26c86557