### PR TITLE
Clip highlighted custom exits to current room

### DIFF
--- a/src/ExitRenderer.ts
+++ b/src/ExitRenderer.ts
@@ -184,6 +184,20 @@ export default class ExitRenderer {
                 console.log("Brak opisu stylu: " + style);
             }
 
+            if (overrideColor) {
+                const padding = Settings.roomSize * 0.1;
+                const clipGroup = new Konva.Group({
+                    clip: {
+                        x: room.x - Settings.roomSize / 2 - padding,
+                        y: room.y - Settings.roomSize / 2 - padding,
+                        width: Settings.roomSize + padding * 2,
+                        height: Settings.roomSize + padding * 2,
+                    },
+                });
+                clipGroup.add(lineRender);
+                return clipGroup;
+            }
+
             return lineRender;
         })
     }


### PR DESCRIPTION
## Summary
- clip highlighted custom exit renders to the current room bounds when applying the overlay color so they no longer cover adjacent rooms

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68e2b317fa54832aa3f87602ad789958