### PR TITLE
Render current room overlay after exits

### DIFF
--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -672,8 +672,6 @@ export class Renderer {
                     strokeEnabled: isCurrent ? Settings.highlightCurrentRoom : false,
                 }
             );
-            this.overlayLayer.add(overlayRoom);
-            this.currentRoomOverlay.push(overlayRoom);
 
             const innerExitColor = isCurrent && Settings.highlightCurrentRoom ? currentRoomColor : undefined;
             this.exitRenderer.renderInnerExits(roomToRedraw, innerExitColor).forEach(render => {
@@ -681,6 +679,9 @@ export class Renderer {
                 this.overlayLayer.add(render);
                 this.currentRoomOverlay.push(render);
             });
+
+            this.overlayLayer.add(overlayRoom);
+            this.currentRoomOverlay.push(overlayRoom);
         });
 
         this.overlayLayer.batchDraw();


### PR DESCRIPTION
## Summary
- ensure the current room overlay group is added after redrawn exits so it renders above them

## Testing
- npm run demo:dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e2c0aac4e0832aa1d28ab054b41873