### PR TITLE
Fix one way exit arrow fill

### DIFF
--- a/src/ExitRenderer.ts
+++ b/src/ExitRenderer.ts
@@ -7,7 +7,8 @@ import {movePoint} from "./directions";
 const Colors = {
     OPEN_DOOR: 'rgb(10, 155, 10)',
     CLOSED_DOOR: 'rgb(226, 205, 59)',
-    LOCKED_DOOR: 'rgb(155, 10, 10)'
+    LOCKED_DOOR: 'rgb(155, 10, 10)',
+    ONE_WAY_FILL: 'rgb(155, 10, 10)'
 }
 
 const dirNumbers: Record<number, MapData.direction> = {
@@ -129,7 +130,7 @@ export default class ExitRenderer {
             pointerWidth: 0.35,
             strokeWidth: 0.035,
             stroke: color,
-            fill: color,
+            fill: Colors.ONE_WAY_FILL,
             dashEnabled: true,
             dash: [0.1, 0.05],
         })


### PR DESCRIPTION
## Summary
- add a dedicated color constant for one-way exit arrow fill
- ensure one-way exit arrows retain their red inner fill when rendered

## Testing
- yarn build *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68e693ae1f40832aa70fe53bc1c3951d