### PR TITLE
Phase 4 (settings contract): add MapRenderer.updateSettings + selective invalidation

### DIFF
--- a/docs/architecture-refactor.md
+++ b/docs/architecture-refactor.md
@@ -288,65 +288,93 @@ the call is a no-op and returns an empty set.
 
 ---
 
-## Phase 5 — Dirty Tracking & Render Scheduling
+## Phase 5 — Dirty Tracking & Render Scheduling ✅
 
-**Goal:** Batch multiple state changes into a single render pass per frame.
+**Status:** Implemented. State mutations and `updateSettings` no longer render
+inline; they OR bit flags into a per-backend `RenderScheduler` that flushes
+once per `requestAnimationFrame` (microtask fallback in non-DOM environments).
 
 ### 5.1 Dirty Flag System
 
+`src/RenderScheduler.ts` defines:
+
 ```ts
-enum DirtyFlag {
-  Rooms      = 1 << 0,
-  Exits      = 1 << 1,
-  Grid       = 1 << 2,
-  Position   = 1 << 3,
-  Highlights = 1 << 4,
-  Path       = 1 << 5,
-  Culling    = 1 << 6,
-}
+export const DirtyFlag = {
+    None: 0,
+    Scene: 1 << 0,           // full scene rebuild (superset)
+    Background: 1 << 1,      // CSS background color
+    Position: 1 << 2,        // position marker + current-room overlay
+    Highlights: 1 << 3,      // highlight overlay
+    Paths: 1 << 4,           // path overlay
+    Culling: 1 << 5,         // visibility / spatial-index pass
+    SceneOverlays: 1 << 6,   // scene overlays
+} as const;
 ```
 
-State-mutating methods set flags instead of rendering immediately:
-- `setPosition()` → sets `DirtyFlag.Position`
-- `renderHighlight()` → sets `DirtyFlag.Highlights`
-- `updateSettings({roomSize})` → sets `DirtyFlag.Rooms | DirtyFlag.Exits`
+`Scene` is a superset: when set, `flush` runs the full `backend.refresh()` and
+the other flags short-circuit.
 
 ### 5.2 Render Scheduler
 
 ```ts
 class RenderScheduler {
-  private dirty: number = 0;
-  private scheduled = false;
-
-  markDirty(flags: number) {
-    this.dirty |= flags;
-    if (!this.scheduled) {
-      this.scheduled = true;
-      requestAnimationFrame(() => this.flush());
-    }
-  }
-
-  private flush() {
-    const flags = this.dirty;
-    this.dirty = 0;
-    this.scheduled = false;
-    // re-render only what's flagged
-    if (flags & DirtyFlag.Rooms) this.renderRooms();
-    if (flags & DirtyFlag.Exits) this.renderExits();
-    // ...
-  }
+    constructor(flushFn: (flags: DirtyFlag) => void);
+    markDirty(flags: DirtyFlag): void;
+    flush(): void;
+    pending(): DirtyFlag;
+    isScheduled(): boolean;
+    destroy(): void;
 }
 ```
 
+`KonvaRenderBackend` owns one scheduler. State events from `MapState` map to
+flags:
+
+| Event       | Flag                 | Notes |
+|-------------|----------------------|-------|
+| `area`      | `Scene`              | full rebuild |
+| `position`  | `Position`           | latches latest `center` / `instant` (OR-merge) |
+| `highlight` | `Highlights`         | uses `syncHighlights` (full re-sync from state) |
+| `path`      | `Paths`              | |
+| `clear`     | `Highlights`         | |
+| `center`    | (synchronous)        | starts a viewport pan animation; subsequent renders batch via `viewport.onChange` |
+
+`MapRenderer.updateSettings()` (Phase 4) now ORs `InvalidationTarget`s into
+`DirtyFlag`s and calls `backend.markDirty(...)` — the work is deferred to the
+next flush along with any concurrent state mutations.
+
 ### 5.3 Immediate Escape Hatch
 
-For cases where the caller needs synchronous rendering (export, tests):
+`MapRenderer.flush()` processes pending flags synchronously. To keep existing
+callers from having to think about batching, `MapRenderer.export()` and the
+`getDrawn*` accessors (`getDrawnExits`, `getDrawnSpecialExits`,
+`getDrawnStubs`) auto-flush before reading.
 
 ```ts
-renderer.flush();  // process all pending dirty flags immediately
+renderer.drawArea(1, 0);
+renderer.renderHighlight(2, '#f00');
+renderer.setPosition(3, true);
+// ... no render yet — all batched.
+renderer.flush();   // exactly one Scene refresh runs.
+// or:
+const svg = renderer.export(new SvgExporter()); // implicit flush.
 ```
 
-**Validation:** Calling `setPosition()` + `renderHighlight()` + `updateSettings()` in the same tick results in exactly one render pass. Measurable FPS improvement on rapid state changes.
+### Validation
+
+`tests/render-scheduler.test.ts` covers:
+- `markDirty` calls before flush coalesce into one `flushFn` invocation
+- `flush()` runs synchronously and clears state
+- `flush()` cancels the scheduled rAF (no double dispatch)
+- `markDirty(None)` and `flush()` with nothing pending are no-ops
+- `destroy()` cancels pending work and silences future `markDirty`
+- `drawArea` defers `backend.refresh` until `flush()`
+- `drawArea + renderHighlight + renderPath + setPosition` in one tick →
+  exactly **one** `backend.refresh` call after `flush()` (Scene short-circuit)
+- `MapRenderer.export()` auto-flushes
+- `updateSettings({backgroundColor})` only invokes `updateBackground`
+- `updateSettings({roomSize})` triggers a single Scene refresh
+- Mixing `updateSettings({roomSize})` with state mutations stays at one refresh
 
 ---
 

--- a/docs/architecture-refactor.md
+++ b/docs/architecture-refactor.md
@@ -378,34 +378,73 @@ const svg = renderer.export(new SvgExporter()); // implicit flush.
 
 ---
 
-## Phase 6 — PathFinder Separation (Optional)
+## Phase 6 — PathFinder Separation ✅
 
-**Goal:** Separate graph construction from pathfinding algorithms.
+**Status:** Implemented. Graph construction lives in `MapGraph` (already
+extracted in an earlier branch) and `PathFinder` consumes it; this phase
+finishes the separation by letting `PathFinder` accept a pre-built
+`MapGraph` directly and adding a synthetic-input factory so the algorithms
+can be tested without a `MapReader` or JSON fixture.
 
-### 6.1 Extract MapGraph
+### 6.1 MapGraph
 
-New file: `src/MapGraph.ts`
+`src/MapGraph.ts` exposes:
 
 ```ts
 class MapGraph {
   constructor(mapReader: MapReader);
-  getNeighbors(roomId: number): Array<{ roomId: number; weight: number; direction: string }>;
-  buildAdjacencyMap(options?: { visitedOnly?: Set<number> }): Map<number, Edge[]>;
+  constructor(synthetic: SyntheticGraphInput);
+  static fromSynthetic(input: SyntheticGraphInput): MapGraph;
+
+  getAdj(): Map<number, Edge[]>;
+  getGraphDefinition(): Record<string, Record<string, number>>;
+  getMaxEdgeDistance(): number;
+  getMinEdgeWeight(): number;
+  getRoom(id: number): RoomLike | undefined;
+}
+
+interface RoomLike { readonly id: number; readonly x: number; readonly y: number; readonly z: number }
+interface SyntheticGraphInput {
+  rooms: ReadonlyArray<RoomLike>;
+  edges: ReadonlyMap<number, ReadonlyArray<Edge>>;
 }
 ```
 
-### 6.2 Simplify PathFinder
+The MapReader path keeps its existing semantics (exit locks, special exits,
+exit weights, cross-area edges). The synthetic path skips all of that and
+just uses the `{rooms, edges}` you hand it — minimum surface needed for the
+A* heuristic (`getRoom(id).{x,y,z}`).
 
-PathFinder becomes algorithm-only:
+### 6.2 PathFinder
+
 ```ts
 class PathFinder {
-  constructor(graph: MapGraph);
-  setAlgorithm(algo: 'dijkstra' | 'astar'): void;
-  findPath(from: number, to: number): number[];
+  constructor(mapReader: MapReader, algorithm?: PathFindingAlgorithm);
+  constructor(graph: MapGraph, algorithm?: PathFindingAlgorithm);
+  get algorithm(): PathFindingAlgorithm;
+  setAlgorithm(algo: PathFindingAlgorithm): void;
+  findPath(from: number, to: number): number[] | null;
 }
 ```
 
-**Validation:** Pathfinding results identical. Can now unit-test pathfinding with synthetic graph fixtures.
+Two `PathFinder`s can share one `MapGraph` (e.g. a Dijkstra and an A*
+instance for parity testing) and the constructor no longer rebuilds the
+graph from the reader.
+
+### Validation
+
+`tests/synthetic-graph.test.ts` covers:
+- `MapGraph.fromSynthetic` builds adj / graphDefinition / minEdgeWeight /
+  maxEdgeDistance from raw `{rooms, edges}` input
+- Edges to unknown room ids are skipped
+- `getRoom` returns the synthetic room shape
+- Dijkstra picks the cheaper multi-hop path over a heavy direct shortcut
+  (1→2→3→4→5 cost 4, beats 1→5 cost 10)
+- A* and Dijkstra agree on the synthetic graph
+- Both algorithms return `null` for disconnected nodes
+- Two `PathFinder`s sharing one `MapGraph` produce consistent results
+- `new PathFinder(reader)` and `new PathFinder(new MapGraph(reader))`
+  produce identical paths on the test fixture across several pairs
 
 ---
 

--- a/docs/architecture-refactor.md
+++ b/docs/architecture-refactor.md
@@ -220,46 +220,71 @@ Room/exit/grid rendering code now lives in one place. Visual bugs get fixed once
 
 ---
 
-## Phase 4 — Settings Contract
+## Phase 4 — Settings Contract ✅
 
-**Goal:** Make settings changes explicit and efficient.
+**Status:** Implemented. Adds an explicit, scoped path for settings updates on
+top of the existing in-place mutation; the underlying `Settings` object reference
+is preserved so the many sub-renderers that hold a long-lived reference (room
+shape, exit, grid, culling, etc.) continue to see the latest values without
+rewiring.
 
-### 4.1 Immutable Settings with Diff
+### 4.1 Diff helper
 
-```ts
-// Settings becomes a frozen object
-const settings = createSettings({ roomSize: 0.6, emboss: true });
-
-// Changes produce a new object + a diff
-const [next, changed] = updateSettings(settings, { roomSize: 0.8 });
-// changed = Set{'roomSize'}
-```
-
-### 4.2 Selective Invalidation
-
-Renderer maps setting keys to what needs re-rendering:
+`src/types/Settings.ts` exposes:
 
 ```ts
-const invalidationMap: Record<string, InvalidationTarget[]> = {
-  roomSize:        ['rooms', 'exits', 'grid'],
-  backgroundColor: ['grid'],
-  lineColor:       ['rooms', 'exits'],
-  gridEnabled:     ['grid'],
-  cullingMode:     ['culling'],
-  // ...
-};
+export type SettingsKey = keyof Settings;
+export function diffSettings(prev: Settings, partial: Partial<Settings>): Set<SettingsKey>;
 ```
 
-`renderer.applySettings(next)` diffs, unions the invalidation targets, and only re-renders what's needed.
+Comparison is reference equality (`!==`); pass a fresh object/array to register
+a nested change. `undefined` values in the partial are skipped.
+
+### 4.2 Selective invalidation
+
+Targets:
+
+| Target       | Effect                                    |
+|--------------|-------------------------------------------|
+| `background` | `backend.updateBackground()`              |
+| `culling`    | `backend.culling.scheduleCulling()`       |
+| `position`   | `state.refreshPosition()`                 |
+| `scene`      | full `backend.refresh()` (superset)       |
+
+```ts
+export const SETTINGS_INVALIDATION: Readonly<Partial<Record<SettingsKey, readonly InvalidationTarget[]>>>;
+export function invalidationTargetsFor(changed: Iterable<SettingsKey>): Set<InvalidationTarget>;
+```
+
+Keys without an explicit entry default to `['scene']`. `instantMapMove` /
+`perfCallback` map to `[]` (no re-render). `cullingMode`, `cullingEnabled`,
+`cullingBounds` map to `['culling']`. `playerMarker`, `highlightCurrentRoom`
+map to `['position']`. `roomShape` maps to `['scene', 'position']`. The full
+table is in `src/types/Settings.ts`.
 
 ### 4.3 Public API
 
+`MapRenderer` adds:
+
 ```ts
-renderer.updateSettings({ roomSize: 0.8 });  // triggers minimal re-render
-renderer.getSettings();                        // returns frozen copy
+renderer.updateSettings({ roomSize: 0.8 });   // returns Set<SettingsKey> of keys that changed
+renderer.getSettings();                         // returns frozen shallow copy (incl. playerMarker)
 ```
 
-**Validation:** Changing `backgroundColor` should not re-render rooms. Changing `roomSize` should re-render rooms + exits but not trigger a full `drawArea()`.
+`updateSettings()` mutates the live settings object in place and dispatches the
+union of invalidation targets. When `scene` is in the union, only the full
+refresh runs (it already covers the others). When the partial changes nothing,
+the call is a no-op and returns an empty set.
+
+### Validation
+
+`tests/settings.test.ts` covers:
+- diff returns the right key set, skips `undefined`, uses `!==` for nested objects
+- invalidation map is total over `keyof Settings` (guards against omissions)
+- `backgroundColor`-only change doesn't change SVG geometry (only the bg fill differs)
+- `roomSize` change rebuilds the scene (SVG materially differs)
+- `cullingMode` change doesn't rebuild the scene (SVG export is byte-identical)
+- `getSettings()` is frozen (top + `playerMarker`) and reflects current values
 
 ---
 

--- a/src/MapGraph.ts
+++ b/src/MapGraph.ts
@@ -27,17 +27,65 @@ export interface GraphData {
 }
 
 /**
+ * Minimum room shape consumed by {@link MapGraph}. The full `MapData.Room`
+ * is a strict superset; the A* heuristic in `PathFinder` only needs spatial
+ * coordinates plus an id.
+ */
+export interface RoomLike {
+    readonly id: number;
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+}
+
+/**
+ * Hand-crafted graph input for `MapGraph.fromSynthetic`. Lets tests and
+ * advanced callers build a graph without going through a {@link MapReader}.
+ */
+export interface SyntheticGraphInput {
+    /** Nodes — each must have a unique `id` and spatial coordinates. */
+    rooms: ReadonlyArray<RoomLike>;
+    /**
+     * Outgoing edges per `roomId`. Edge weights are used as-is.
+     * Rooms with no outgoing edges may omit the entry.
+     */
+    edges: ReadonlyMap<number, ReadonlyArray<Edge>>;
+}
+
+/**
  * Builds a weighted adjacency graph from MapReader room/exit data.
  * Separated from PathFinder so the graph can be reused and tested independently.
+ *
+ * For algorithm-only tests, see {@link MapGraph.fromSynthetic} which builds
+ * a graph from a hand-crafted `{ rooms, edges }` input — no `MapReader` or
+ * `MapData.Room` instances required.
  */
 export class MapGraph {
 
-    private readonly mapReader: MapReader;
+    private readonly getRoomImpl: (id: number) => RoomLike | undefined;
     private readonly data: GraphData;
 
-    constructor(mapReader: MapReader) {
-        this.mapReader = mapReader;
-        this.data = this.buildGraph();
+    constructor(mapReader: MapReader);
+    constructor(synthetic: SyntheticGraphInput);
+    constructor(arg: MapReader | SyntheticGraphInput) {
+        if (arg instanceof MapReader) {
+            this.getRoomImpl = (id) => arg.getRoom(id);
+            this.data = MapGraph.buildFromReader(arg);
+        } else {
+            const rooms = new Map<number, RoomLike>();
+            for (const r of arg.rooms) rooms.set(r.id, r);
+            this.getRoomImpl = (id) => rooms.get(id);
+            this.data = MapGraph.buildFromSynthetic(arg, rooms);
+        }
+    }
+
+    /**
+     * Build a `MapGraph` from raw `{ rooms, edges }` input. Equivalent to
+     * `new MapGraph(syntheticInput)`; this static form reads more naturally
+     * in tests and at call sites that already destructure their fixture.
+     */
+    static fromSynthetic(input: SyntheticGraphInput): MapGraph {
+        return new MapGraph(input);
     }
 
     getAdj(): Map<number, Edge[]> {
@@ -56,23 +104,25 @@ export class MapGraph {
         return this.data.minEdgeWeight;
     }
 
-    getRoom(roomId: number) {
-        return this.mapReader.getRoom(roomId);
+    getRoom(roomId: number): RoomLike | undefined {
+        return this.getRoomImpl(roomId);
     }
 
-    private resolveEdgeWeight(room: MapData.Room, exitWeightKey: string, target: MapData.Room): number {
+    private static resolveEdgeWeight(
+        room: MapData.Room, exitWeightKey: string, target: MapData.Room,
+    ): number {
         const exitWeight = room.exitWeights?.[exitWeightKey];
         if (exitWeight !== undefined && exitWeight > 0) return exitWeight;
         return Math.max(target.weight, 1);
     }
 
-    private buildGraph(): GraphData {
+    private static buildFromReader(mapReader: MapReader): GraphData {
         const adj = new Map<number, Edge[]>();
         const graphDefinition: Record<string, Record<string, number>> = {};
         let maxEdgeDist = 1;
         let minEdgeWeight = Infinity;
 
-        this.mapReader.getRooms().forEach(room => {
+        mapReader.getRooms().forEach(room => {
             const edges: Edge[] = [];
             const connections: Record<string, number> = {};
 
@@ -86,10 +136,10 @@ export class MapGraph {
 
             Object.entries(room.exits ?? {}).forEach(([direction, targetRoomId]) => {
                 if (lockedDirections.has(direction as MapData.direction)) return;
-                const target = this.mapReader.getRoom(targetRoomId);
+                const target = mapReader.getRoom(targetRoomId);
                 if (target) {
                     const weightKey = directionToExitWeightKey[direction as MapData.direction] ?? direction;
-                    const weight = this.resolveEdgeWeight(room, weightKey, target);
+                    const weight = MapGraph.resolveEdgeWeight(room, weightKey, target);
                     edges.push({id: targetRoomId, weight});
                     connections[targetRoomId.toString()] = weight;
                     if (weight < minEdgeWeight) minEdgeWeight = weight;
@@ -103,9 +153,9 @@ export class MapGraph {
 
             Object.entries(room.specialExits ?? {}).forEach(([exitCommand, targetRoomId]) => {
                 if (lockedSpecialTargets.has(targetRoomId)) return;
-                const target = this.mapReader.getRoom(targetRoomId);
+                const target = mapReader.getRoom(targetRoomId);
                 if (target) {
-                    const weight = this.resolveEdgeWeight(room, exitCommand, target);
+                    const weight = MapGraph.resolveEdgeWeight(room, exitCommand, target);
                     edges.push({id: targetRoomId, weight});
                     connections[targetRoomId.toString()] = weight;
                     if (weight < minEdgeWeight) minEdgeWeight = weight;
@@ -120,6 +170,40 @@ export class MapGraph {
             adj.set(room.id, edges);
             graphDefinition[room.id.toString()] = connections;
         });
+
+        if (!isFinite(minEdgeWeight)) minEdgeWeight = 1;
+
+        return {adj, graphDefinition, maxEdgeDistance: maxEdgeDist, minEdgeWeight};
+    }
+
+    private static buildFromSynthetic(
+        input: SyntheticGraphInput,
+        roomsById: ReadonlyMap<number, RoomLike>,
+    ): GraphData {
+        const adj = new Map<number, Edge[]>();
+        const graphDefinition: Record<string, Record<string, number>> = {};
+        let maxEdgeDist = 1;
+        let minEdgeWeight = Infinity;
+
+        for (const room of input.rooms) {
+            const incoming = input.edges.get(room.id) ?? [];
+            const edges: Edge[] = [];
+            const connections: Record<string, number> = {};
+            for (const e of incoming) {
+                const target = roomsById.get(e.id);
+                if (!target) continue;
+                edges.push({id: e.id, weight: e.weight});
+                connections[e.id.toString()] = e.weight;
+                if (e.weight < minEdgeWeight) minEdgeWeight = e.weight;
+                const dx = target.x - room.x;
+                const dy = target.y - room.y;
+                const dz = target.z - room.z;
+                const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+                if (dist > maxEdgeDist) maxEdgeDist = dist;
+            }
+            adj.set(room.id, edges);
+            graphDefinition[room.id.toString()] = connections;
+        }
 
         if (!isFinite(minEdgeWeight)) minEdgeWeight = 1;
 

--- a/src/PathFinder.ts
+++ b/src/PathFinder.ts
@@ -123,9 +123,11 @@ export default class PathFinder {
     private _algorithm: PathFindingAlgorithm;
     private readonly cache = new Map<string, number[] | null>();
 
-    constructor(mapReader: MapReader, algorithm: PathFindingAlgorithm = 'dijkstra') {
+    constructor(mapReader: MapReader, algorithm?: PathFindingAlgorithm);
+    constructor(graph: MapGraph, algorithm?: PathFindingAlgorithm);
+    constructor(source: MapReader | MapGraph, algorithm: PathFindingAlgorithm = 'dijkstra') {
         this._algorithm = algorithm;
-        this.mapGraph = new MapGraph(mapReader);
+        this.mapGraph = source instanceof MapGraph ? source : new MapGraph(source);
         this.dijkstraGraph = new Graph(this.mapGraph.getGraphDefinition());
     }
 

--- a/src/RenderScheduler.ts
+++ b/src/RenderScheduler.ts
@@ -1,0 +1,113 @@
+/**
+ * Bit flags describing portions of the rendered output that need to be
+ * recomputed. Multiple flags can be OR'd together; the scheduler unions
+ * pending flags across the current tick and dispatches them in one pass.
+ *
+ * `Scene` is a strict superset of every other flag: when set, the flush
+ * runs the full scene rebuild (which already updates background, position,
+ * highlights, paths, culling and scene overlays) and the other flags are
+ * cleared without further work.
+ */
+export const DirtyFlag = {
+    None: 0,
+    Scene: 1 << 0,
+    Background: 1 << 1,
+    Position: 1 << 2,
+    Highlights: 1 << 3,
+    Paths: 1 << 4,
+    Culling: 1 << 5,
+    SceneOverlays: 1 << 6,
+} as const;
+
+export type DirtyFlag = number;
+
+/**
+ * Coalesces dirty-flag updates across a tick and dispatches them in a single
+ * `requestAnimationFrame` callback (or microtask in environments without rAF).
+ *
+ * Callers mark portions of the scene dirty via {@link markDirty}; the actual
+ * rendering work lives in the `flushFn` constructor argument and runs at most
+ * once per tick. {@link flush} processes pending work synchronously — useful
+ * for exports, tests, and any caller that needs to read rendered state on
+ * the same tick.
+ */
+export class RenderScheduler {
+    private dirty: DirtyFlag = DirtyFlag.None;
+    private scheduled = false;
+    private rafId?: number;
+    private destroyed = false;
+
+    private readonly schedule: (cb: () => void) => number;
+    private readonly cancel: (id: number) => void;
+    private readonly flushFn: (flags: DirtyFlag) => void;
+
+    constructor(flushFn: (flags: DirtyFlag) => void) {
+        this.flushFn = flushFn;
+        if (typeof requestAnimationFrame === 'function') {
+            this.schedule = (cb) => requestAnimationFrame(cb);
+            this.cancel = (id) => cancelAnimationFrame(id);
+        } else {
+            this.schedule = (cb) => setTimeout(cb, 0) as unknown as number;
+            this.cancel = (id) => clearTimeout(id as unknown as ReturnType<typeof setTimeout>);
+        }
+    }
+
+    /**
+     * OR `flags` into the pending set. Schedules a flush on the next frame
+     * if one isn't already pending. `DirtyFlag.None` is a no-op.
+     */
+    markDirty(flags: DirtyFlag) {
+        if (this.destroyed || flags === DirtyFlag.None) return;
+        this.dirty |= flags;
+        if (!this.scheduled) {
+            this.scheduled = true;
+            this.rafId = this.schedule(() => this.runFlush());
+        }
+    }
+
+    /** True if a flush is currently scheduled (but has not yet run). */
+    isScheduled(): boolean {
+        return this.scheduled;
+    }
+
+    /** Currently pending flags, or `DirtyFlag.None`. */
+    pending(): DirtyFlag {
+        return this.dirty;
+    }
+
+    /**
+     * Process pending flags now. Cancels any scheduled rAF callback and
+     * runs the flush function synchronously. Safe to call when nothing is
+     * pending — it's a no-op in that case.
+     */
+    flush() {
+        if (this.rafId !== undefined) {
+            this.cancel(this.rafId);
+            this.rafId = undefined;
+        }
+        this.runFlush();
+    }
+
+    /**
+     * Cancel any scheduled flush and clear pending flags without running
+     * `flushFn`. Used during teardown.
+     */
+    destroy() {
+        this.destroyed = true;
+        if (this.rafId !== undefined) {
+            this.cancel(this.rafId);
+            this.rafId = undefined;
+        }
+        this.dirty = DirtyFlag.None;
+        this.scheduled = false;
+    }
+
+    private runFlush() {
+        this.scheduled = false;
+        this.rafId = undefined;
+        const flags = this.dirty;
+        if (flags === DirtyFlag.None) return;
+        this.dirty = DirtyFlag.None;
+        this.flushFn(flags);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export { MapState } from './MapState';
 export type { MapStateEventMap, HighlightEntry, PathEntry } from './MapState';
 export { KonvaRenderBackend } from './rendering/KonvaRenderBackend';
 export { Viewport } from './Viewport';
+export { RenderScheduler, DirtyFlag } from './RenderScheduler';
 
 // --- Drawing primitives ---
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,13 @@
 // --- Settings, types, colour utils ---
-export { createSettings } from './types/Settings';
+export {
+    createSettings, diffSettings, invalidationTargetsFor, SETTINGS_INVALIDATION,
+} from './types/Settings';
 export type {
     Settings, ViewportBounds, RendererEventMap, PerfSnapshot,
     CullingMode, RoomShape, LabelRenderMode, PlayerMarkerStyle,
     RoomClickEventDetail, RoomContextMenuEventDetail,
     ZoomChangeEventDetail, AreaExitClickEventDetail, PanEventDetail,
+    SettingsKey, InvalidationTarget,
 } from './types/Settings';
 export { darkenColor, colorLightness, hexToRgba } from './utils/color';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export { default as MapReader } from './reader/MapReader';
 export { default as PathFinder } from './PathFinder';
 export type { PathFindingAlgorithm } from './PathFinder';
 export { MapGraph } from './MapGraph';
-export type { Edge, GraphData } from './MapGraph';
+export type { Edge, GraphData, RoomLike, SyntheticGraphInput } from './MapGraph';
 export { default as ExplorationArea } from './reader/ExplorationArea';
 
 // --- Area map ---

--- a/src/rendering/KonvaRenderBackend.ts
+++ b/src/rendering/KonvaRenderBackend.ts
@@ -8,6 +8,7 @@ import type {MapState} from "../MapState";
 import {Viewport} from "../Viewport";
 import {CullingManager} from "../CullingManager";
 import {InteractionHandler} from "../InteractionHandler";
+import {RenderScheduler, DirtyFlag} from "../RenderScheduler";
 import {TypedEventEmitter} from "../TypedEventEmitter";
 import {KonvaLayerNode} from "../backend/KonvaBackend";
 import {CanvasBackend, RecordingLayerNode} from "../backend/CanvasBackend";
@@ -79,6 +80,10 @@ export class KonvaRenderBackend implements InteractiveBackend {
     private sceneOverlays: Map<string, SceneOverlay> = new Map();
     private sceneOverlayNodes: Map<string, GroupNode[]> = new Map();
     private viewportSubscribers: Set<() => void> = new Set();
+    private readonly scheduler: RenderScheduler;
+    /** Latched parameters for the next batched position flush. */
+    private pendingPositionCenter = false;
+    private pendingPositionInstant = false;
 
     constructor(state: MapState, container?: HTMLDivElement, drawingBackend?: DrawingBackend) {
         this.state = state;
@@ -156,8 +161,54 @@ export class KonvaRenderBackend implements InteractiveBackend {
             }, this.events);
         }
 
+        this.scheduler = new RenderScheduler((flags) => this.flushFlags(flags));
+
         this.applyDrawingBackendTransforms(this.drawingBackend);
         this.subscribeToState(state);
+    }
+
+    /** Process pending dirty flags synchronously. */
+    flush() {
+        this.scheduler.flush();
+    }
+
+    /** OR `flags` into the pending set; flush runs on the next frame. */
+    markDirty(flags: DirtyFlag) {
+        this.scheduler.markDirty(flags);
+    }
+
+    private flushFlags(flags: DirtyFlag) {
+        // Scene is the superset; refresh() rebuilds everything.
+        if (flags & DirtyFlag.Scene) {
+            this.pendingPositionCenter = false;
+            this.pendingPositionInstant = false;
+            this.refresh();
+            return;
+        }
+        if (flags & DirtyFlag.Background) {
+            this.updateBackground();
+        }
+        if (flags & DirtyFlag.Highlights) {
+            this.syncHighlights();
+        }
+        if (flags & DirtyFlag.Paths) {
+            this.syncPaths();
+        }
+        if (flags & DirtyFlag.Position) {
+            const center = this.pendingPositionCenter;
+            const instant = this.pendingPositionInstant;
+            this.pendingPositionCenter = false;
+            this.pendingPositionInstant = false;
+            this.onPositionChanged(this.state.positionRoomId, center, instant);
+        }
+        if (flags & DirtyFlag.SceneOverlays) {
+            for (const [id, overlay] of this.sceneOverlays) {
+                this.renderSceneOverlay(id, overlay);
+            }
+        }
+        if (flags & DirtyFlag.Culling) {
+            this.culling.scheduleCulling();
+        }
     }
 
     setDrawingBackend(backend: DrawingBackend) {
@@ -236,6 +287,9 @@ export class KonvaRenderBackend implements InteractiveBackend {
     destroy() {
         if (this.destroyed) return;
         this.destroyed = true;
+
+        // Cancel any pending scheduled flush
+        this.scheduler.destroy();
 
         // Remove all MapState event subscriptions
         this.state.events.removeAllListeners();
@@ -523,14 +577,20 @@ export class KonvaRenderBackend implements InteractiveBackend {
 
     private subscribeToState(state: MapState) {
         state.events.on('area', () => {
-            this.refresh();
+            this.scheduler.markDirty(DirtyFlag.Scene);
         });
 
-        state.events.on('position', ({roomId, center, areaChanged}) => {
-            this.onPositionChanged(roomId, center, areaChanged);
+        state.events.on('position', ({center, areaChanged}) => {
+            // OR-merge across the tick: any setPosition with center=true
+            // should still center; same for the area-changed → instant flag.
+            this.pendingPositionCenter ||= center;
+            this.pendingPositionInstant ||= areaChanged;
+            this.scheduler.markDirty(DirtyFlag.Position);
         });
 
         state.events.on('center', ({roomId, instant}) => {
+            // Pan animations are time-sensitive; start them synchronously.
+            // The animation will then drive batched renders via viewport.onChange.
             const room = state.mapReader.getRoom(roomId);
             if (room) {
                 const p = this.mapPoint(room.x, room.y);
@@ -539,16 +599,16 @@ export class KonvaRenderBackend implements InteractiveBackend {
             }
         });
 
-        state.events.on('highlight', ({roomId, color}) => {
-            this.syncHighlight(roomId, color);
+        state.events.on('highlight', () => {
+            this.scheduler.markDirty(DirtyFlag.Highlights);
         });
 
         state.events.on('path', () => {
-            this.syncPaths();
+            this.scheduler.markDirty(DirtyFlag.Paths);
         });
 
         state.events.on('clear', () => {
-            this.syncHighlights();
+            this.scheduler.markDirty(DirtyFlag.Highlights);
         });
     }
 

--- a/src/rendering/MapRenderer.ts
+++ b/src/rendering/MapRenderer.ts
@@ -1,7 +1,7 @@
 import MapReader from "../reader/MapReader";
 import type Area from "../reader/Area";
-import type {ViewportBounds, RendererEventMap, CullingMode} from "../types/Settings";
-import {createSettings} from "../types/Settings";
+import type {ViewportBounds, RendererEventMap, CullingMode, SettingsKey, InvalidationTarget} from "../types/Settings";
+import {createSettings, diffSettings, invalidationTargetsFor} from "../types/Settings";
 import type {Settings} from "../types/Settings";
 import {MapState} from "../MapState";
 import {KonvaRenderBackend} from "./KonvaRenderBackend";
@@ -195,6 +195,57 @@ export class MapRenderer {
     refresh() {
         this.backend.updateBackground();
         this.backend.refresh();
+    }
+
+    /**
+     * Apply a partial update to the current settings and re-render only
+     * what the changed keys require (per `SETTINGS_INVALIDATION`).
+     *
+     * Returns the set of keys whose value actually changed. When nothing
+     * changed (shallow `!==` compare against the current values), the
+     * returned set is empty and no work is performed.
+     *
+     * ```ts
+     * renderer.updateSettings({backgroundColor: '#fff'}); // background only
+     * renderer.updateSettings({roomSize: 0.8});            // full scene rebuild
+     * renderer.updateSettings({cullingMode: 'none'});      // culling pass only
+     * ```
+     */
+    updateSettings(partial: Partial<Settings>): Set<SettingsKey> {
+        const settings = this.state.settings;
+        const changed = diffSettings(settings, partial);
+        if (changed.size === 0) return changed;
+
+        for (const key of changed) {
+            (settings as Record<string, unknown>)[key] = (partial as Record<string, unknown>)[key];
+        }
+
+        const targets = invalidationTargetsFor(changed);
+        this.applyInvalidationTargets(targets);
+        return changed;
+    }
+
+    /**
+     * Returns a frozen shallow copy of the current settings (the nested
+     * `playerMarker` is also frozen). Use {@link updateSettings} to mutate.
+     */
+    getSettings(): Readonly<Settings> {
+        const s = this.state.settings;
+        return Object.freeze({
+            ...s,
+            playerMarker: Object.freeze({...s.playerMarker}),
+        });
+    }
+
+    private applyInvalidationTargets(targets: Set<InvalidationTarget>) {
+        if (targets.has('scene')) {
+            // `refresh()` already covers background, culling, and position.
+            this.refresh();
+            return;
+        }
+        if (targets.has('background')) this.backend.updateBackground();
+        if (targets.has('culling')) this.backend.culling.scheduleCulling();
+        if (targets.has('position')) this.state.refreshPosition();
     }
 
     // --- Overlays ---

--- a/src/rendering/MapRenderer.ts
+++ b/src/rendering/MapRenderer.ts
@@ -8,6 +8,7 @@ import {KonvaRenderBackend} from "./KonvaRenderBackend";
 import type {DrawingBackend, CoordFn, Style} from "../backend/DrawingBackend";
 import {identityStyle} from "../backend/DrawingBackend";
 import {CanvasBackend} from "../backend/CanvasBackend";
+import {DirtyFlag} from "../RenderScheduler";
 import type {Viewport} from "../Viewport";
 import type {CullingManager} from "../CullingManager";
 import type {TypedEventEmitter} from "../TypedEventEmitter";
@@ -26,6 +27,10 @@ export interface InteractiveBackend {
     setDrawingBackend(backend: DrawingBackend): void;
     updateBackground(): void;
     refresh(): void;
+    /** Mark portions of the rendered output dirty; flushed on the next frame. */
+    markDirty(flags: DirtyFlag): void;
+    /** Process pending dirty flags synchronously. */
+    flush(): void;
     /** Render a specific region to canvas (for headless / bounded export). */
     toCanvas(options: {
         width: number;
@@ -198,6 +203,22 @@ export class MapRenderer {
     }
 
     /**
+     * Process any pending batched render work synchronously.
+     *
+     * State mutations (`drawArea`, `setPosition`, `renderHighlight`, …) and
+     * `updateSettings` mark portions of the rendered output dirty and let the
+     * backend coalesce them into one frame. Call `flush()` when you need to
+     * read rendered state on the same tick (exports, hit-test data, tests).
+     *
+     * `export()` and the `getDrawn*` accessors flush automatically — explicit
+     * calls are only needed when reading external state derived from the
+     * Konva stage.
+     */
+    flush() {
+        this.backend.flush();
+    }
+
+    /**
      * Apply a partial update to the current settings and re-render only
      * what the changed keys require (per `SETTINGS_INVALIDATION`).
      *
@@ -238,14 +259,12 @@ export class MapRenderer {
     }
 
     private applyInvalidationTargets(targets: Set<InvalidationTarget>) {
-        if (targets.has('scene')) {
-            // `refresh()` already covers background, culling, and position.
-            this.refresh();
-            return;
-        }
-        if (targets.has('background')) this.backend.updateBackground();
-        if (targets.has('culling')) this.backend.culling.scheduleCulling();
-        if (targets.has('position')) this.state.refreshPosition();
+        let flags: DirtyFlag = DirtyFlag.None;
+        if (targets.has('scene'))      flags |= DirtyFlag.Scene;
+        if (targets.has('background')) flags |= DirtyFlag.Background;
+        if (targets.has('culling'))    flags |= DirtyFlag.Culling;
+        if (targets.has('position'))   flags |= DirtyFlag.Position;
+        this.backend.markDirty(flags);
     }
 
     // --- Overlays ---
@@ -277,11 +296,13 @@ export class MapRenderer {
      * patterns, one-way arrows, and the renderer's suppression rules.
      */
     getDrawnExits(): readonly DrawnExitEntry[] {
+        this.backend.flush();
         return this.backend.getDrawnExits();
     }
 
     /** Companion to {@link getDrawnExits} for custom-line special exits. */
     getDrawnSpecialExits(): readonly DrawnSpecialExitEntry[] {
+        this.backend.flush();
         return this.backend.getDrawnSpecialExits();
     }
 
@@ -291,6 +312,7 @@ export class MapRenderer {
      * render space and match what's on screen.
      */
     getDrawnStubs(): readonly DrawnStubEntry[] {
+        this.backend.flush();
         return this.backend.getDrawnStubs();
     }
 
@@ -307,6 +329,11 @@ export class MapRenderer {
      * ```
      */
     export<T>(exporter: Exporter<T>): T {
+        // Flush any batched render work so exporters that read backend state
+        // (canvas/PNG via `backend.toCanvas`) see the up-to-date scene. SVG
+        // export builds its own pipeline and is unaffected, but the cost is
+        // a no-op when nothing is pending.
+        this.backend.flush();
         const context: ExportContext = {
             state: this.state,
             backend: this.backend,

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -186,6 +186,89 @@ export type Settings = {
     areaExitLabelFontSize: number;
 };
 
+/** Keys of {@link Settings}. */
+export type SettingsKey = keyof Settings;
+
+/**
+ * Targets a settings change can invalidate. The renderer re-runs only the
+ * paths matching the union of targets across all changed keys.
+ *
+ * - `background` — container CSS background color
+ * - `culling`    — visibility/spatial-index pass
+ * - `position`   — current-room marker + highlight overlay
+ * - `scene`      — full scene rebuild (rooms, exits, grid, labels)
+ *
+ * `scene` is a superset of the others: when present, only the scene rebuild
+ * runs (it already updates background and re-emits position/culling).
+ */
+export type InvalidationTarget = 'background' | 'culling' | 'position' | 'scene';
+
+/**
+ * Per-key invalidation map. Keys absent from this map fall back to
+ * `['scene']` (full rebuild).
+ */
+export const SETTINGS_INVALIDATION: Readonly<Partial<Record<SettingsKey, readonly InvalidationTarget[]>>> = Object.freeze({
+    backgroundColor: ['background'] as const,
+    cullingEnabled: ['culling'] as const,
+    cullingMode: ['culling'] as const,
+    cullingBounds: ['culling'] as const,
+    instantMapMove: [] as const,
+    perfCallback: [] as const,
+    playerMarker: ['position'] as const,
+    highlightCurrentRoom: ['position'] as const,
+    roomShape: ['scene', 'position'] as const,
+    roomSize: ['scene'] as const,
+    lineWidth: ['scene'] as const,
+    lineColor: ['scene'] as const,
+    labelRenderMode: ['scene'] as const,
+    transparentLabels: ['scene'] as const,
+    gridEnabled: ['scene'] as const,
+    gridSize: ['scene'] as const,
+    gridColor: ['scene'] as const,
+    gridLineWidth: ['scene'] as const,
+    borders: ['scene'] as const,
+    frameMode: ['scene'] as const,
+    coloredMode: ['scene'] as const,
+    emboss: ['scene'] as const,
+    areaName: ['scene'] as const,
+    fontFamily: ['scene'] as const,
+    uniformLevelSize: ['scene'] as const,
+    areaExitLabels: ['scene'] as const,
+    areaExitLabelFontSize: ['scene'] as const,
+});
+
+/**
+ * Diff a partial settings update against the current settings.
+ * Comparison is reference equality (`!==`) — pass a fresh object/array if
+ * you want a nested change to register.
+ *
+ * Keys whose value in `partial` is `undefined` are skipped. The returned
+ * Set contains only keys whose value would actually change.
+ */
+export function diffSettings(prev: Settings, partial: Partial<Settings>): Set<SettingsKey> {
+    const changed = new Set<SettingsKey>();
+    for (const key of Object.keys(partial) as SettingsKey[]) {
+        const next = partial[key];
+        if (next === undefined) continue;
+        if (prev[key] !== next) changed.add(key);
+    }
+    return changed;
+}
+
+/**
+ * Union of invalidation targets for the given changed keys.
+ * Keys without an explicit entry in {@link SETTINGS_INVALIDATION} default
+ * to `['scene']`.
+ */
+export function invalidationTargetsFor(changed: Iterable<SettingsKey>): Set<InvalidationTarget> {
+    const targets = new Set<InvalidationTarget>();
+    for (const key of changed) {
+        const list = SETTINGS_INVALIDATION[key] ?? (['scene'] as const);
+        for (const t of list) targets.add(t);
+    }
+    return targets;
+}
+
 /** Creates a new Settings object with default values. */
 export function createSettings(): Settings {
     return {

--- a/tests/render-scheduler.test.ts
+++ b/tests/render-scheduler.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RenderScheduler, DirtyFlag } from '../src/RenderScheduler';
+import { MapRenderer } from '../src/rendering/MapRenderer';
+import { SvgExporter } from '../src/export/SvgExporter';
+import { createSettings } from '../src/types/Settings';
+import { createTestMapReader } from './helpers';
+
+describe('RenderScheduler', () => {
+    it('coalesces markDirty calls before a flush into one flushFn invocation', async () => {
+        const flushFn = vi.fn();
+        const scheduler = new RenderScheduler(flushFn);
+
+        scheduler.markDirty(DirtyFlag.Highlights);
+        scheduler.markDirty(DirtyFlag.Paths);
+        scheduler.markDirty(DirtyFlag.Position);
+
+        expect(flushFn).not.toHaveBeenCalled();
+        expect(scheduler.pending()).toBe(
+            DirtyFlag.Highlights | DirtyFlag.Paths | DirtyFlag.Position,
+        );
+        expect(scheduler.isScheduled()).toBe(true);
+
+        await new Promise((r) => setTimeout(r, 32));
+
+        expect(flushFn).toHaveBeenCalledTimes(1);
+        expect(flushFn).toHaveBeenCalledWith(
+            DirtyFlag.Highlights | DirtyFlag.Paths | DirtyFlag.Position,
+        );
+        expect(scheduler.pending()).toBe(DirtyFlag.None);
+        expect(scheduler.isScheduled()).toBe(false);
+    });
+
+    it('flush() runs pending work synchronously and clears state', () => {
+        const flushFn = vi.fn();
+        const scheduler = new RenderScheduler(flushFn);
+        scheduler.markDirty(DirtyFlag.Scene);
+        scheduler.flush();
+        expect(flushFn).toHaveBeenCalledTimes(1);
+        expect(flushFn).toHaveBeenCalledWith(DirtyFlag.Scene);
+        expect(scheduler.pending()).toBe(DirtyFlag.None);
+        expect(scheduler.isScheduled()).toBe(false);
+    });
+
+    it('flush() with nothing pending is a no-op', () => {
+        const flushFn = vi.fn();
+        const scheduler = new RenderScheduler(flushFn);
+        scheduler.flush();
+        expect(flushFn).not.toHaveBeenCalled();
+    });
+
+    it('flush() cancels the scheduled rAF callback (no double dispatch)', async () => {
+        const flushFn = vi.fn();
+        const scheduler = new RenderScheduler(flushFn);
+        scheduler.markDirty(DirtyFlag.Highlights);
+        scheduler.flush();
+        expect(flushFn).toHaveBeenCalledTimes(1);
+
+        await new Promise((r) => setTimeout(r, 32));
+        expect(flushFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('markDirty(None) is a no-op', () => {
+        const flushFn = vi.fn();
+        const scheduler = new RenderScheduler(flushFn);
+        scheduler.markDirty(DirtyFlag.None);
+        expect(scheduler.isScheduled()).toBe(false);
+        scheduler.flush();
+        expect(flushFn).not.toHaveBeenCalled();
+    });
+
+    it('destroy() cancels pending work and silences future markDirty', async () => {
+        const flushFn = vi.fn();
+        const scheduler = new RenderScheduler(flushFn);
+        scheduler.markDirty(DirtyFlag.Scene);
+        scheduler.destroy();
+        scheduler.markDirty(DirtyFlag.Scene);
+        await new Promise((r) => setTimeout(r, 32));
+        expect(flushFn).not.toHaveBeenCalled();
+    });
+});
+
+describe('MapRenderer batching (Phase 5)', () => {
+    function makeRenderer() {
+        const reader = createTestMapReader();
+        const settings = createSettings();
+        return new MapRenderer(reader, settings);
+    }
+
+    it('drawArea defers backend.refresh until flush()', () => {
+        const r = makeRenderer();
+        const refreshSpy = vi.spyOn(r.backend, 'refresh');
+        r.drawArea(1, 0);
+        expect(refreshSpy).not.toHaveBeenCalled();
+
+        r.flush();
+        expect(refreshSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('multiple state mutations in the same tick flush as one Scene refresh', () => {
+        const r = makeRenderer();
+        // Bootstrap so that subsequent mutations are not the first area set.
+        r.drawArea(1, 0);
+        r.flush();
+
+        const refreshSpy = vi.spyOn(r.backend, 'refresh');
+
+        r.drawArea(1, 0);            // Scene
+        r.renderHighlight(1, '#f00'); // Highlights
+        r.renderPath([1, 2, 3]);      // Paths
+        r.setPosition(1, true);       // Position
+
+        expect(refreshSpy).not.toHaveBeenCalled();
+
+        r.flush();
+        // Scene flag short-circuits the others — exactly one refresh.
+        expect(refreshSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('export() auto-flushes pending work', () => {
+        const r = makeRenderer();
+        const refreshSpy = vi.spyOn(r.backend, 'refresh');
+        r.drawArea(1, 0);
+        const svg = r.export(new SvgExporter());
+        // SvgExporter is independent of backend.refresh (builds its own pipeline),
+        // but export() still calls backend.flush() to keep canvas/PNG exports
+        // consistent — so the area Scene flush should have run.
+        expect(refreshSpy).toHaveBeenCalledTimes(1);
+        expect(svg).toBeDefined();
+        expect(svg).toContain('<svg');
+    });
+
+    it('updateSettings background-only does not refresh the scene', () => {
+        const r = makeRenderer();
+        r.drawArea(1, 0);
+        r.flush();
+
+        const refreshSpy = vi.spyOn(r.backend, 'refresh');
+        const updateBgSpy = vi.spyOn(r.backend, 'updateBackground');
+
+        r.updateSettings({ backgroundColor: '#abcdef' });
+        r.flush();
+
+        expect(refreshSpy).not.toHaveBeenCalled();
+        expect(updateBgSpy).toHaveBeenCalled();
+    });
+
+    it('updateSettings roomSize triggers a single Scene refresh', () => {
+        const r = makeRenderer();
+        r.drawArea(1, 0);
+        r.flush();
+
+        const refreshSpy = vi.spyOn(r.backend, 'refresh');
+        r.updateSettings({ roomSize: 0.9 });
+        r.flush();
+        expect(refreshSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('mixing updateSettings(scene) with state mutations stays at one refresh', () => {
+        const r = makeRenderer();
+        r.drawArea(1, 0);
+        r.flush();
+
+        const refreshSpy = vi.spyOn(r.backend, 'refresh');
+        r.updateSettings({ roomSize: 0.9 });
+        r.renderHighlight(1, '#f00');
+        r.setPosition(2, false);
+        r.flush();
+        expect(refreshSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import { MapRenderer } from '../src/rendering/MapRenderer';
+import { SvgExporter } from '../src/export/SvgExporter';
+import {
+    createSettings, diffSettings, invalidationTargetsFor, SETTINGS_INVALIDATION,
+} from '../src/types/Settings';
+import type { Settings } from '../src/types/Settings';
+import { createTestMapReader } from './helpers';
+
+function makeRenderer(settingsOverrides?: Partial<Settings>) {
+    const reader = createTestMapReader();
+    const settings = { ...createSettings(), ...settingsOverrides };
+    const renderer = new MapRenderer(reader, settings);
+    renderer.drawArea(1, 0);
+    return renderer;
+}
+
+describe('diffSettings', () => {
+    it('returns empty set when partial matches current values', () => {
+        const s = createSettings();
+        const changed = diffSettings(s, { roomSize: s.roomSize, lineColor: s.lineColor });
+        expect(changed.size).toBe(0);
+    });
+
+    it('returns set of keys whose values differ', () => {
+        const s = createSettings();
+        const changed = diffSettings(s, { roomSize: 0.9, gridEnabled: true, lineColor: s.lineColor });
+        expect([...changed].sort()).toEqual(['gridEnabled', 'roomSize']);
+    });
+
+    it('skips keys explicitly set to undefined', () => {
+        const s = createSettings();
+        const changed = diffSettings(s, { roomSize: undefined });
+        expect(changed.size).toBe(0);
+    });
+
+    it('uses reference equality for nested objects', () => {
+        const s = createSettings();
+        const sameRef = diffSettings(s, { playerMarker: s.playerMarker });
+        expect(sameRef.size).toBe(0);
+
+        const newMarker = { ...s.playerMarker };
+        const newRef = diffSettings(s, { playerMarker: newMarker });
+        expect(newRef.has('playerMarker')).toBe(true);
+    });
+});
+
+describe('invalidationTargetsFor', () => {
+    it('maps backgroundColor to background only', () => {
+        const targets = invalidationTargetsFor(['backgroundColor']);
+        expect([...targets]).toEqual(['background']);
+    });
+
+    it('maps cullingMode to culling only', () => {
+        const targets = invalidationTargetsFor(['cullingMode']);
+        expect([...targets]).toEqual(['culling']);
+    });
+
+    it('maps roomShape to scene + position', () => {
+        const targets = invalidationTargetsFor(['roomShape']);
+        expect(targets.has('scene')).toBe(true);
+        expect(targets.has('position')).toBe(true);
+    });
+
+    it('unions targets across multiple keys', () => {
+        const targets = invalidationTargetsFor(['backgroundColor', 'cullingMode', 'roomSize']);
+        expect(targets.has('background')).toBe(true);
+        expect(targets.has('culling')).toBe(true);
+        expect(targets.has('scene')).toBe(true);
+    });
+
+    it('returns empty for keys with no invalidation (e.g. instantMapMove)', () => {
+        const targets = invalidationTargetsFor(['instantMapMove']);
+        expect(targets.size).toBe(0);
+    });
+
+    it('every Settings key appears in SETTINGS_INVALIDATION', () => {
+        // Guards against forgetting to map a new setting.
+        const sample = createSettings();
+        for (const key of Object.keys(sample)) {
+            expect(
+                SETTINGS_INVALIDATION,
+                `Missing invalidation entry for "${key}"`,
+            ).toHaveProperty(key);
+        }
+    });
+});
+
+describe('MapRenderer.updateSettings', () => {
+    it('returns the set of keys that actually changed', () => {
+        const renderer = makeRenderer();
+        const current = renderer.state.settings;
+        const changed = renderer.updateSettings({
+            roomSize: 0.85,
+            lineColor: current.lineColor, // unchanged
+        });
+        expect([...changed]).toEqual(['roomSize']);
+    });
+
+    it('returns empty set and no-ops when nothing changed', () => {
+        const renderer = makeRenderer();
+        const before = renderer.export(new SvgExporter());
+        const changed = renderer.updateSettings({
+            roomSize: renderer.state.settings.roomSize,
+            backgroundColor: renderer.state.settings.backgroundColor,
+        });
+        expect(changed.size).toBe(0);
+        expect(renderer.export(new SvgExporter())).toBe(before);
+    });
+
+    it('mutates the underlying settings object in place', () => {
+        const renderer = makeRenderer();
+        const settingsRef = renderer.state.settings;
+        renderer.updateSettings({ roomSize: 0.9 });
+        expect(settingsRef.roomSize).toBe(0.9);
+        // Same reference — sub-renderers retain validity.
+        expect(renderer.state.settings).toBe(settingsRef);
+    });
+
+    it('background-only change does not rebuild rooms (rect data identical)', () => {
+        // SVG output differs only in the bg fill string when only background changes.
+        const r1 = makeRenderer();
+        const before = r1.export(new SvgExporter())!;
+        r1.updateSettings({ backgroundColor: '#123456' });
+        const after = r1.export(new SvgExporter())!;
+
+        expect(before).not.toBe(after);
+        // Background change reflected in the SVG fill rect.
+        expect(after).toContain('#123456');
+
+        // Stripping the background fill values makes the two SVGs identical.
+        const stripBg = (s: string) => s.replace(/fill="(#000000|#123456)"/g, 'fill="BG"');
+        expect(stripBg(before)).toBe(stripBg(after));
+    });
+
+    it('roomSize change rebuilds the scene (SVG materially differs)', () => {
+        const r = makeRenderer();
+        const before = r.export(new SvgExporter())!;
+        r.updateSettings({ roomSize: 1.2 });
+        const after = r.export(new SvgExporter())!;
+        expect(after).not.toBe(before);
+        // Rebuilt scene → same scene structure, but with different room geometry.
+        // Crude sanity check: width/height attrs reference roomSize, so length differs.
+        expect(after.length).not.toBe(before.length);
+    });
+
+    it('cullingMode change updates settings without rebuilding scene', () => {
+        const r = makeRenderer();
+        const before = r.export(new SvgExporter())!;
+        const changed = r.updateSettings({ cullingMode: 'none' });
+        expect(changed.has('cullingMode')).toBe(true);
+        expect(r.state.settings.cullingMode).toBe('none');
+        // SVG export is independent of culling mode (no viewport bounds).
+        expect(r.export(new SvgExporter())).toBe(before);
+    });
+});
+
+describe('MapRenderer.getSettings', () => {
+    it('returns a frozen shallow copy', () => {
+        const r = makeRenderer();
+        const snap = r.getSettings();
+        expect(Object.isFrozen(snap)).toBe(true);
+        expect(Object.isFrozen(snap.playerMarker)).toBe(true);
+    });
+
+    it('reflects current values', () => {
+        const r = makeRenderer();
+        r.updateSettings({ roomSize: 0.7, gridEnabled: true });
+        const snap = r.getSettings();
+        expect(snap.roomSize).toBe(0.7);
+        expect(snap.gridEnabled).toBe(true);
+    });
+
+    it('mutating the snapshot does not affect state', () => {
+        const r = makeRenderer();
+        const snap = r.getSettings();
+        // Mutation is silently ignored in non-strict mode and throws in strict.
+        // Either way, the underlying state must not change.
+        try { (snap as unknown as Settings).roomSize = 99; } catch { /* expected */ }
+        expect(r.state.settings.roomSize).not.toBe(99);
+    });
+});

--- a/tests/synthetic-graph.test.ts
+++ b/tests/synthetic-graph.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { MapGraph } from '../src/MapGraph';
+import type { Edge, SyntheticGraphInput } from '../src/MapGraph';
+import PathFinder from '../src/PathFinder';
+import { createTestMapReader } from './helpers';
+
+/**
+ * Phase 6 validation: pathfinding can be exercised end-to-end against a
+ * hand-crafted graph with no MapReader / JSON fixture in the loop.
+ *
+ * Layout — a 5-node line graph with a shortcut, all on the z=0 plane:
+ *
+ *     (1) ── 1 ──> (2) ── 1 ──> (3) ── 1 ──> (4) ── 1 ──> (5)
+ *      └────── 10 ──────────────> (5)              ^
+ *                                                   │
+ *      (6, isolated)
+ *
+ * Edge weights make the linear path (1→2→3→4→5, total = 4) cheaper than
+ * the direct shortcut (1→5, weight 10).
+ */
+function lineWithShortcut(): SyntheticGraphInput {
+    const rooms = [
+        { id: 1, x: 0, y: 0, z: 0 },
+        { id: 2, x: 1, y: 0, z: 0 },
+        { id: 3, x: 2, y: 0, z: 0 },
+        { id: 4, x: 3, y: 0, z: 0 },
+        { id: 5, x: 4, y: 0, z: 0 },
+        { id: 6, x: 99, y: 99, z: 0 }, // disconnected
+    ];
+    const edges = new Map<number, Edge[]>([
+        [1, [{ id: 2, weight: 1 }, { id: 5, weight: 10 }]],
+        [2, [{ id: 3, weight: 1 }]],
+        [3, [{ id: 4, weight: 1 }]],
+        [4, [{ id: 5, weight: 1 }]],
+    ]);
+    return { rooms, edges };
+}
+
+describe('MapGraph.fromSynthetic', () => {
+    it('builds adjacency from raw {rooms, edges}', () => {
+        const g = MapGraph.fromSynthetic(lineWithShortcut());
+        const adj = g.getAdj();
+        expect([...adj.keys()].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 6]);
+        expect(adj.get(1)!.map(e => e.id).sort((a, b) => a - b)).toEqual([2, 5]);
+        expect(adj.get(6)!.length).toBe(0);
+    });
+
+    it('skips edges to unknown room ids', () => {
+        const g = MapGraph.fromSynthetic({
+            rooms: [{ id: 1, x: 0, y: 0, z: 0 }],
+            edges: new Map([[1, [{ id: 999, weight: 1 }]]]),
+        });
+        expect(g.getAdj().get(1)!.length).toBe(0);
+    });
+
+    it('computes minEdgeWeight and maxEdgeDistance from inputs', () => {
+        const g = MapGraph.fromSynthetic(lineWithShortcut());
+        // Min weight: 1. Max distance: 4 (between 1 and 5 along x).
+        expect(g.getMinEdgeWeight()).toBe(1);
+        expect(g.getMaxEdgeDistance()).toBe(4);
+    });
+
+    it('graphDefinition mirrors adj for node-dijkstra', () => {
+        const g = MapGraph.fromSynthetic(lineWithShortcut());
+        const def = g.getGraphDefinition();
+        expect(def['1']).toEqual({ '2': 1, '5': 10 });
+        expect(def['6']).toEqual({});
+    });
+
+    it('returns synthetic rooms via getRoom (without MapReader)', () => {
+        const g = MapGraph.fromSynthetic(lineWithShortcut());
+        expect(g.getRoom(3)).toEqual({ id: 3, x: 2, y: 0, z: 0 });
+        expect(g.getRoom(999)).toBeUndefined();
+    });
+});
+
+describe('PathFinder with synthetic MapGraph', () => {
+    it('dijkstra finds the cheaper multi-hop path over the heavy shortcut', () => {
+        const graph = MapGraph.fromSynthetic(lineWithShortcut());
+        const pf = new PathFinder(graph, 'dijkstra');
+        // 1→2→3→4→5 (cost 4) beats the 1→5 shortcut (cost 10).
+        expect(pf.findPath(1, 5)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('astar agrees with dijkstra on the synthetic graph', () => {
+        const graph = MapGraph.fromSynthetic(lineWithShortcut());
+        const a = new PathFinder(graph, 'astar');
+        const d = new PathFinder(graph, 'dijkstra');
+        expect(a.findPath(1, 5)).toEqual(d.findPath(1, 5));
+    });
+
+    it('returns null for the disconnected node', () => {
+        const graph = MapGraph.fromSynthetic(lineWithShortcut());
+        expect(new PathFinder(graph, 'dijkstra').findPath(1, 6)).toBeNull();
+        expect(new PathFinder(graph, 'astar').findPath(1, 6)).toBeNull();
+    });
+
+    it('two PathFinders can share one MapGraph', () => {
+        const graph = MapGraph.fromSynthetic(lineWithShortcut());
+        const a = new PathFinder(graph, 'dijkstra');
+        const b = new PathFinder(graph, 'astar');
+        const pa = a.findPath(1, 5);
+        const pb = b.findPath(1, 5);
+        expect(pa).not.toBeNull();
+        expect(pb).not.toBeNull();
+        expect(pa![pa!.length - 1]).toBe(5);
+        expect(pb![pb!.length - 1]).toBe(5);
+    });
+});
+
+describe('PathFinder accepts a pre-built MapGraph from a real reader', () => {
+    it('produces identical results to the MapReader-based constructor', () => {
+        const reader = createTestMapReader();
+        const graph = new MapGraph(reader);
+
+        const fromReader = new PathFinder(reader, 'dijkstra');
+        const fromGraph = new PathFinder(graph, 'dijkstra');
+
+        for (const [from, to] of [[1, 6], [6, 3], [4, 10], [1, 20]]) {
+            expect(fromGraph.findPath(from, to)).toEqual(fromReader.findPath(from, to));
+        }
+    });
+});


### PR DESCRIPTION
Adds a scoped settings update path on top of existing in-place mutation:

- diffSettings(prev, partial) -> Set<SettingsKey> using reference equality
- SETTINGS_INVALIDATION map: keys -> {background|culling|position|scene}
- invalidationTargetsFor(keys) unions the targets across keys (default 'scene')
- MapRenderer.updateSettings(partial): mutates settings in place, applies the
  minimal re-render union, returns the changed keys
- MapRenderer.getSettings(): frozen shallow copy (+ frozen playerMarker)

The settings object reference is preserved so sub-renderers (RoomShape, Exit,
Grid, Culling, ...) that hold long-lived references continue to see updates.

Tests in tests/settings.test.ts cover diff/union semantics, completeness of
the invalidation map over keyof Settings, and end-to-end behavior:
backgroundColor-only changes don't alter SVG geometry, roomSize rebuilds the
scene, cullingMode does not.